### PR TITLE
fix(api): bound BTC-balance provider fetches so /api/v2/balance/{address} can't hang (#1198)

### DIFF
--- a/lib/utils/bitcoin/network/mempool.ts
+++ b/lib/utils/bitcoin/network/mempool.ts
@@ -2,6 +2,37 @@ const MAX_RETRIES = 3;
 import { MEMPOOL_API_BASE_URL } from "$constants";
 import type { BTCBalance, MempoolAddressResponse } from "$lib/types/index.d.ts";
 
+// Default deadline for external balance/API fetches. Without a timeout a hung
+// upstream (mempool.space / BlockCypher) blocks the caller indefinitely — this
+// is what hung the aggregate `/api/v2/balance/{address}` endpoint (#1198).
+export const DEFAULT_FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * `fetch` with an `AbortController` deadline so a slow/unresponsive upstream
+ * fails fast instead of hanging the caller. On timeout it throws an `Error`
+ * with `name === "TimeoutError"`; otherwise it behaves exactly like `fetch`.
+ */
+export async function fetchWithTimeout(
+  input: string | URL,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+  init: RequestInit = {},
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      const timeoutError = new Error(`Request timed out after ${timeoutMs}ms`);
+      timeoutError.name = "TimeoutError";
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 interface RecommendedFees {
   fastestFee: number;
   halfHourFee: number;
@@ -93,7 +124,7 @@ export const getBTCBalanceFromMempool = async (
 ): Promise<BTCBalance | null> => {
   try {
     const endpoint = `${MEMPOOL_API_BASE_URL}/address/${address}`;
-    const response = await fetch(endpoint);
+    const response = await fetchWithTimeout(endpoint);
     if (!response.ok) {
       throw new Error(
         `Error: response for: ${endpoint} unsuccessful. Response: ${response.status}`,
@@ -114,6 +145,13 @@ export const getBTCBalanceFromMempool = async (
       unconfirmedTxCount: data.mempool_stats.tx_count,
     };
   } catch (error) {
+    // A timeout means the upstream is unresponsive; retrying just re-accumulates
+    // the delay (MAX_RETRIES x timeout) — exactly what let this hang the aggregate
+    // balance endpoint (#1198). Fail fast so the caller can fall through / degrade.
+    if (error instanceof Error && error.name === "TimeoutError") {
+      console.error("Mempool balance fetch timed out:", error);
+      return null;
+    }
     if (retries < MAX_RETRIES) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       return await getBTCBalanceFromMempool(address, retries + 1);

--- a/lib/utils/data/processing/balanceUtils.ts
+++ b/lib/utils/data/processing/balanceUtils.ts
@@ -6,14 +6,17 @@ import {
 } from "$lib/types/index.d.ts";
 import { BLOCKCYPHER_API_BASE_URL } from "$constants";
 import { formatSatoshisToBTC, formatUSDValue } from "$lib/utils/formatUtils.ts";
-import { getBTCBalanceFromMempool } from "$lib/utils/mempool.ts";
+import {
+  fetchWithTimeout,
+  getBTCBalanceFromMempool,
+} from "$lib/utils/mempool.ts";
 import { dbManager } from "$server/database/databaseManager.ts";
 
 async function getBTCBalanceFromBlockCypher(
   address: string,
 ): Promise<BTCBalance | null> {
   try {
-    const response = await fetch(
+    const response = await fetchWithTimeout(
       `${BLOCKCYPHER_API_BASE_URL}/v1/btc/main/addrs/${address}/balance`,
     );
     if (!response.ok) return null;

--- a/tests/unit/utils/fetchWithTimeout.test.ts
+++ b/tests/unit/utils/fetchWithTimeout.test.ts
@@ -1,0 +1,88 @@
+import { assert, assertEquals } from "@std/assert";
+import { stub } from "@std/testing@1.0.14/mock";
+import {
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchWithTimeout,
+  getBTCBalanceFromMempool,
+} from "$lib/utils/mempool.ts";
+
+// Regression coverage for #1198: the aggregate /api/v2/balance/{address} endpoint
+// hung 20s+ because the BTC-balance providers issued fetch() with no timeout, so a
+// slow upstream blocked the request indefinitely. fetchWithTimeout bounds each
+// fetch, and the mempool provider no longer retries a timeout (which used to
+// re-accumulate the delay).
+
+Deno.test("fetchWithTimeout returns the response when fetch resolves", async () => {
+  const okResp = new Response("ok", { status: 200 });
+  const fetchStub = stub(globalThis, "fetch", () => Promise.resolve(okResp));
+  try {
+    const res = await fetchWithTimeout("https://example.com/", 1000);
+    assertEquals(res.status, 200);
+    assertEquals(fetchStub.calls.length, 1);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("fetchWithTimeout throws a TimeoutError when the upstream hangs", async () => {
+  // Simulate a hung upstream: resolve/reject only when the abort signal fires.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      }),
+  );
+  try {
+    let caught: unknown;
+    try {
+      await fetchWithTimeout("https://example.com/", 20); // 20ms deadline
+    } catch (e) {
+      caught = e;
+    }
+    assert(caught instanceof Error, "expected an Error to be thrown");
+    assertEquals((caught as Error).name, "TimeoutError");
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("fetchWithTimeout passes non-timeout errors through unchanged", async () => {
+  const boom = new Error("network down");
+  const fetchStub = stub(globalThis, "fetch", () => Promise.reject(boom));
+  try {
+    let caught: unknown;
+    try {
+      await fetchWithTimeout("https://example.com/", 1000);
+    } catch (e) {
+      caught = e;
+    }
+    assertEquals(caught, boom); // same error, not converted to TimeoutError
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("DEFAULT_FETCH_TIMEOUT_MS is a sane positive deadline", () => {
+  assert(DEFAULT_FETCH_TIMEOUT_MS > 0 && DEFAULT_FETCH_TIMEOUT_MS <= 15000);
+});
+
+Deno.test("getBTCBalanceFromMempool returns null and does NOT retry on timeout", async () => {
+  // An AbortError from fetch becomes a TimeoutError in fetchWithTimeout; the
+  // mempool provider must fail fast (single call, no MAX_RETRIES re-accumulation).
+  const abortErr = new Error("aborted");
+  abortErr.name = "AbortError";
+  const fetchStub = stub(globalThis, "fetch", () => Promise.reject(abortErr));
+  try {
+    const result = await getBTCBalanceFromMempool("bc1qexampleaddress");
+    assertEquals(result, null);
+    assertEquals(fetchStub.calls.length, 1); // exactly one attempt — no retry
+  } finally {
+    fetchStub.restore();
+  }
+});


### PR DESCRIPTION
Addresses #1198.

## Problem

`GET /api/v2/balance/{address}` hangs (20s+, no response) while the granular `GET /api/v2/stamps/balance/{address}` and `GET /api/v2/src20/balance/{address}` return instantly for the same address.

The difference: the aggregate handler additionally awaits `getBTCBalanceInfo(address)` inside a `Promise.all`, and that path fetches BTC balance from mempool.space / BlockCypher (`lib/utils/data/processing/balanceUtils.ts` + `lib/utils/bitcoin/network/mempool.ts`) via `fetch()` with **no timeout**. When that upstream is slow/unresponsive the fetch never settles, so the whole endpoint blocks. The mempool provider also retries (`MAX_RETRIES` ×, 1s apart), which only re-accumulates the delay.

## Fix

- **`mempool.ts`** — add `fetchWithTimeout()` (an `AbortController` deadline; throws an `Error` with `name === "TimeoutError"` on the deadline, otherwise behaves exactly like `fetch`). `getBTCBalanceFromMempool` uses it and **no longer retries on a timeout** — a timeout won't recover in 1s, and retrying tripled the hang.
- **`balanceUtils.ts`** — the BlockCypher provider uses `fetchWithTimeout` too.

Now a slow provider **fails fast** and the provider loop degrades gracefully: `getBTCBalanceInfo` returns `null`, and the handler already renders BTC balance `0` (`btcInfo?.balance ?? 0`). So the endpoint returns the stamps/SRC-20 payload promptly instead of hanging. This benefits **every** caller of these providers (wallet adapters, dashboard, etc.), not just this endpoint.

## Tests

`tests/unit/utils/fetchWithTimeout.test.ts`:
- returns the response on success (passthrough);
- throws `TimeoutError` when the upstream hangs (real `AbortController` deadline);
- passes non-timeout errors through unchanged;
- `getBTCBalanceFromMempool` returns `null` and makes exactly **one** attempt (no retry) on a timeout.

Local (Deno 2.1.4): `deno fmt --check`, `deno lint`, `deno check` (changed files), and `deno test` unit (5 passed / 0 failed) all green.

## Notes / scope

- Consensus-irrelevant (explorer/API, not the indexer).
- I could not reproduce the live prod hang locally (no MySQL/Redis stack), so this is a root-cause fix + defensive hardening rather than a locally-reproduced repro. Worst case is now bounded (~one `DEFAULT_FETCH_TIMEOUT_MS` per provider; normally sub-second on a Redis cache hit) instead of unbounded.
- A hard per-request ceiling at the handler level (bounding `getBTCBalanceInfo` in the route) is a possible follow-up if you'd want a guaranteed sub-5s response even when both providers are simultaneously slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)