### PR TITLE
feat(wallet): add Wonder Wallet connect adapter

### DIFF
--- a/.cursor/rules/development_workflow.mdc
+++ b/.cursor/rules/development_workflow.mdc
@@ -8,6 +8,11 @@ development_workflow:
     development:
       command: "deno task dev"
       options: "--inspect --allow-all --watch --no-clear-screen"
+      local_https:
+        flag: "LOCAL_HTTPS in lib/utils/dataPlaceholderProd.ts"
+        committed_default: false
+        crash: "LOCAL_HTTPS is true but localhost-cert.pem / localhost-key.pem are missing."
+        fix: "Set LOCAL_HTTPS = false unless the developer generated gitignored localhost-*.pem and wants https://localhost:8000"
       excludes:
         - "dist/"
         - "node_modules/"

--- a/.cursor/rules/environment.mdc
+++ b/.cursor/rules/environment.mdc
@@ -1,9 +1,8 @@
 ---
 description: "Information on environment variables (e.g., DENO_ENV, SKIP_REDIS_CONNECTION) and different runtime environments (development, production)."
-globs: ["deno.json", "main.ts", "dev.ts", "Dockerfile", "*.yml"]
+globs: ["deno.json", "main.ts", "dev.ts", "Dockerfile", "*.yml", "fresh.config.ts", "lib/utils/dataPlaceholderProd.ts"]
 alwaysApply: true
 ---
-
 
 # Environment and configuration
 environment:
@@ -17,3 +16,49 @@ environment:
     - DENO_ENV
     - DEV_BASE_URL
     - SKIP_REDIS_CONNECTION
+
+# Local HTTPS toggle (wallet testing)
+
+`LOCAL_HTTPS` in [dataPlaceholderProd.ts](mdc:lib/utils/dataPlaceholderProd.ts)
+turns Fresh TLS on for `https://localhost:8000`. Wired in
+[fresh.config.ts](mdc:fresh.config.ts). Cert files are gitignored.
+
+**Committed default must be `false`.** Production and other developers use
+plain HTTP locally; AWS terminates TLS. Never commit `LOCAL_HTTPS = true`
+or `localhost-cert.pem` / `localhost-key.pem`.
+
+## Crash if left `true` without certs
+
+`deno task dev` / `deno task start` fails immediately with:
+
+```
+LOCAL_HTTPS is true but localhost-cert.pem / localhost-key.pem are missing.
+```
+
+**Fix for other developers (restore HTTP):** set `LOCAL_HTTPS = false` in
+`lib/utils/dataPlaceholderProd.ts`. Do not generate certs unless they asked
+for local HTTPS.
+
+Same sibling flag: `DATA_PLACEHOLDER_DEV` in that file must also stay
+`false` in committed code (dummy UI data, not a crash).
+
+## Opt-in local HTTPS (Wonder Wallet and similar)
+
+Wonder Wallet rejects `http://localhost`. To serve HTTPS locally:
+
+1. Generate an X.509 **v3** cert (Deno rejects v1:
+   `UnsupportedCertVersion`):
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 \
+  -keyout localhost-key.pem -out localhost-cert.pem \
+  -days 365 -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+  -addext "keyUsage=digitalSignature,keyEncipherment" \
+  -addext "extendedKeyUsage=serverAuth" \
+  -addext "basicConstraints=CA:FALSE"
+```
+
+2. Set `LOCAL_HTTPS = true` in `lib/utils/dataPlaceholderProd.ts`.
+3. Open `https://localhost:8000` (browser will warn on the self-signed cert).
+4. Set the flag back to `false` before committing.

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ sample-data/
 *.bak
 *.test.json
 *.sample.json
+# Local self-signed HTTPS for wallet testing (LOCAL_HTTPS flag)
+localhost-cert.pem
+localhost-key.pem
 # Personal/local files
 TODO.md
 NOTES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,16 @@ Use `deno task dev:safe` to clean up before running the dev server.
   `REDIS_SETUP.md`.
 - Development defaults to `https://dev.stampchain.io`; production to
   `https://stampchain.io`.
+- **Local HTTPS (`LOCAL_HTTPS`)** in
+  `lib/utils/dataPlaceholderProd.ts`, applied by `fresh.config.ts`.
+  Committed value **must be `false`**. If `deno task dev` crashes with
+  `LOCAL_HTTPS is true but localhost-cert.pem / localhost-key.pem are
+  missing`, set the flag back to `false` (certs are gitignored; other
+  developers should not need them). Only set `true` locally for wallets
+  that reject `http://localhost` (e.g. Wonder Wallet); generate an
+  X.509 v3 cert (see `.cursor/rules/environment.mdc`) and never commit
+  the flag or the `.pem` files. `DATA_PLACEHOLDER_DEV` in the same file
+  must likewise stay `false` in committed code.
 
 ## 5. Import Conventions
 - Use import maps defined in `deno.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ stampchain.io is the **official Bitcoin Stamps block explorer and API**. This is
 
 **Production Build Artifacts**:
 - `dist/` directory - Build output
-- `coverage/` - Test coverage reports  
+- `coverage/` - Test coverage reports
 - `reports/` - Newman test reports
 - `tmp/` - Temporary files
 
@@ -56,7 +56,7 @@ stampchain.io is the **official Bitcoin Stamps block explorer and API**. This is
 Adapted for Deno Fresh development:
 
 - **QPLAN**: "Analyze deno.json tasks, existing route patterns, and database models before implementing. Check Fresh islands architecture and SSR considerations."
-- **QCODE**: "Implement with proper TypeScript types, run `deno task check`, validate OpenAPI schema, test both SSR and client-side functionality"  
+- **QCODE**: "Implement with proper TypeScript types, run `deno task check`, validate OpenAPI schema, test both SSR and client-side functionality"
 - **QCHECK**: "Perform security review focusing on data integrity, caching correctness, API response validation, and Fresh architecture patterns"
 
 ### Extended Thinking Triggers
@@ -174,7 +174,7 @@ const stamp = await repo.getStampById("1"); // Returns fixture data
 
 **Security Headers** (configured in `server/middleware/securityHeaders.ts`):
 - Content Security Policy for XSS protection
-- HSTS for HTTPS enforcement  
+- HSTS for HTTPS enforcement
 - CORS configured for API access
 - Rate limiting on API endpoints
 
@@ -202,7 +202,7 @@ export const handler: Handlers = {
   async GET(req, ctx) {
     const { id } = ctx.params;
     const stampData = await getCachedStampData(id);
-    
+
     return Response.json({
       success: true,
       data: stampData,
@@ -221,7 +221,7 @@ import { StampData } from "$types/stamps.ts";
 export default function StampViewer({ stampId }: { stampId: string }) {
   const loading = useSignal(false);
   // Client-side functionality only
-  
+
   return <div>...</div>;
 }
 ```
@@ -231,11 +231,11 @@ export default function StampViewer({ stampId }: { stampId: string }) {
 // lib/database/stampQueries.ts
 export async function getStampById(id: string): Promise<StampData | null> {
   const query = `
-    SELECT * FROM stamps 
-    WHERE stamp_id = ? 
+    SELECT * FROM stamps
+    WHERE stamp_id = ?
     AND block_index IS NOT NULL
   `;
-  
+
   const [rows] = await db.execute(query, [id]);
   return rows[0] || null;
 }
@@ -268,7 +268,7 @@ export async function getStampById(id: string): Promise<StampData | null> {
 # Memory monitoring
 deno task monitor:memory --url=http://localhost:8000
 
-# Performance monitoring  
+# Performance monitoring
 deno task deploy:benchmark
 
 # Health checks
@@ -295,6 +295,9 @@ curl http://localhost:8000/api/health
 - SSR hydration mismatches - validate with `deno task check:ssr`
 - Route parameter extraction - use `ctx.params` correctly
 - Static file serving from `static/` directory
+- `LOCAL_HTTPS = true` in `lib/utils/dataPlaceholderProd.ts` makes Fresh require
+  gitignored `localhost-*.pem` files and will crash `deno task dev` for anyone
+  who does not have them. Committed default is `false`.
 
 **Bitcoin Stamps Specific**:
 - Transaction validation requires proper secp256k1 handling
@@ -304,6 +307,13 @@ curl http://localhost:8000/api/health
 - `client/bitcoinInit.ts` is orphaned (no imports) - not in client build graph, no crypto bundle bloat
 
 ### Troubleshooting Commands
+
+**`LOCAL_HTTPS is true but localhost-cert.pem / localhost-key.pem are missing`:**
+Someone left the local-HTTPS toggle on in `lib/utils/dataPlaceholderProd.ts`.
+Set `LOCAL_HTTPS = false` and restart. Do not generate certs unless the
+developer asked for `https://localhost:8000` (Wonder Wallet and similar
+reject plain `http://localhost`). Never commit `LOCAL_HTTPS = true` or
+the gitignored `.pem` files. Full steps: `.cursor/rules/environment.mdc`.
 
 **Development Issues**:
 ```bash

--- a/client/wallet/wallet.ts
+++ b/client/wallet/wallet.ts
@@ -23,8 +23,9 @@ declare global {
   }
 }
 
-// Move interfaces and variables to the top
-interface WalletProviders {
+// Injected extension providers on window. Named separately from the
+// WalletProviders alias (WalletProviderKey string union) in $types.
+export interface GlobalWalletProviders {
   LeatherProvider?: any;
   okxwallet?: any;
   unisat?: any;
@@ -186,7 +187,7 @@ if (typeof globalThis !== "undefined" && "addEventListener" in globalThis) {
 }
 
 // Provider checking functions
-export function getGlobalWallets(): WalletProviders {
+export function getGlobalWallets(): GlobalWalletProviders {
   // Skip provider checks if we're not in a browser context
   if (typeof globalThis === "undefined" || !("document" in globalThis)) {
     return {};

--- a/client/wallet/wallet.ts
+++ b/client/wallet/wallet.ts
@@ -32,6 +32,7 @@ interface WalletProviders {
   phantom?: any;
   HorizonWalletProvider?: any;
   XverseProviders?: { BitcoinProvider?: any };
+  wonderWallet?: any;
 }
 
 // Initialize wallet state
@@ -200,6 +201,7 @@ export function getGlobalWallets(): WalletProviders {
       tapwallet?: unknown;
       phantom?: { bitcoin?: { isPhantom?: boolean } };
       HorizonWalletProvider?: unknown;
+      wonderWallet?: unknown;
     };
 
     logger.debug("ui", {
@@ -211,6 +213,7 @@ export function getGlobalWallets(): WalletProviders {
         hasTapWallet: Boolean(global.tapwallet),
         hasPhantom: Boolean(global.phantom?.bitcoin?.isPhantom),
         hasHorizon: Boolean(global.HorizonWalletProvider),
+        hasWonder: Boolean(global.wonderWallet),
         timestamp: new Date().toISOString(),
       },
     });
@@ -222,6 +225,7 @@ export function getGlobalWallets(): WalletProviders {
       tapwallet: global.tapwallet,
       phantom: global.phantom,
       HorizonWalletProvider: global.HorizonWalletProvider,
+      wonderWallet: global.wonderWallet,
     };
   } catch (_error) {
     // Silently handle wallet detection errors to prevent console spam
@@ -254,6 +258,8 @@ export function checkWalletAvailability(provider: string): boolean {
       return !!wallets.HorizonWalletProvider;
     case "xverse":
       return !!wallets.XverseProviders?.BitcoinProvider;
+    case "wonder":
+      return !!wallets.wonderWallet;
     default:
       return false;
   }

--- a/client/wallet/walletHelper.ts
+++ b/client/wallet/walletHelper.ts
@@ -4,6 +4,7 @@ import { okxProvider } from "$client/wallet/okx.ts";
 import { phantomProvider } from "$client/wallet/phantom.ts";
 import { tapWalletProvider } from "$client/wallet/tapwallet.ts";
 import { unisatProvider } from "$client/wallet/unisat.ts";
+import { wonderProvider } from "$client/wallet/wonder.ts";
 import { xverseProvider } from "$client/wallet/xverse.ts";
 import { logger } from "$lib/utils/logger.ts";
 import type { SignPSBTResult, Wallet } from "$types/index.d.ts";
@@ -181,6 +182,8 @@ export const getWalletProvider = (
       return horizonProvider;
     case "xverse":
       return xverseProvider;
+    case "wonder":
+      return wonderProvider;
     default:
       throw new Error(`Unsupported wallet provider: ${provider}`);
   }

--- a/client/wallet/wonder.ts
+++ b/client/wallet/wonder.ts
@@ -7,6 +7,7 @@ import {
   handleWalletError,
   parseConnectionError,
 } from "$client/wallet/walletHelper.ts";
+import { extractPrevTxsFromPSBT } from "$lib/utils/bitcoin/psbt/psbtUtils.ts";
 import { base64ToHex } from "$lib/utils/data/binary/baseUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
 import type { BaseToast } from "$lib/utils/ui/notifications/toastSignal.ts";
@@ -169,6 +170,10 @@ interface WonderSignOptions {
     address: string;
     sighashTypes?: number[] | undefined;
   }[];
+  // Legacy (P2PKH/P2SH) inputs require the full previous transaction. Wonder
+  // reads it from opts.prevTxs (keyed by display txid), not from the PSBT's own
+  // nonWitnessUtxo, so we hand it across.
+  prevTxs?: Record<string, string>;
 }
 
 interface WonderSignResult {
@@ -203,6 +208,14 @@ export const signPSBT = async (
         address: walletContext.wallet.address,
         sighashTypes,
       }));
+    }
+
+    // Legacy inputs can't be signed without their previous transactions. Our
+    // PSBTs already embed those as nonWitnessUtxo, so extract them into the
+    // prevTxs map Wonder expects. SegWit-only PSBTs yield an empty map (no-op).
+    const prevTxs = extractPrevTxsFromPSBT(psbtHex);
+    if (Object.keys(prevTxs).length > 0) {
+      options.prevTxs = prevTxs;
     }
 
     const rawResult = await wonder.signPsbt(psbtHex, options);

--- a/client/wallet/wonder.ts
+++ b/client/wallet/wonder.ts
@@ -1,0 +1,194 @@
+import {
+  checkWalletAvailability,
+  getGlobalWallets,
+  walletContext,
+} from "$client/wallet/wallet.ts";
+import {
+  handleWalletError,
+  parseConnectionError,
+} from "$client/wallet/walletHelper.ts";
+import { logger } from "$lib/utils/logger.ts";
+import type { BaseToast } from "$lib/utils/ui/notifications/toastSignal.ts";
+import type { SignPSBTResult, Wallet } from "$types/index.d.ts";
+import { signal } from "@preact/signals";
+
+export const isWonderInstalled = signal<boolean>(false);
+
+export const checkWonder = () => {
+  const isAvailable = checkWalletAvailability("wonder");
+  isWonderInstalled.value = isAvailable;
+  return isAvailable;
+};
+
+const getProvider = () => {
+  const wallets = getGlobalWallets();
+  return wallets.wonderWallet;
+};
+
+export const connectWonder = async (
+  addToast: (message: string, type: BaseToast["type"]) => void,
+) => {
+  try {
+    const wonder = getProvider();
+    if (!wonder) {
+      logger.error("ui", {
+        message: "Wonder Wallet not detected",
+        context: "connectWonder",
+      });
+      addToast(
+        "Wonder Wallet not detected.\nPlease install the Wonder Wallet extension.",
+        "error",
+      );
+      return;
+    }
+    const accounts = await wonder.requestAccounts();
+    await handleAccountsChanged(accounts);
+    logger.info("ui", {
+      message: "Successfully connected to Wonder Wallet",
+      context: "connectWonder",
+    });
+    addToast("Connected using Wonder Wallet.", "success");
+  } catch (error: unknown) {
+    const errorMessage = parseConnectionError(error);
+    logger.error("ui", {
+      message: "Failed to connect to Wonder Wallet",
+      context: "connectWonder",
+      error: errorMessage,
+    });
+    addToast(
+      `Failed to connect to Wonder Wallet.\n${errorMessage}`,
+      "error",
+    );
+  }
+};
+
+const handleAccountsChanged = async (accounts: string[]) => {
+  if (!accounts || accounts.length === 0) {
+    walletContext.disconnect();
+    return;
+  }
+  if (walletContext.wallet.address === accounts[0]) {
+    return;
+  }
+  const wonder = getProvider();
+  const wallet = {} as Wallet;
+  wallet.accounts = accounts;
+  wallet.address = accounts[0];
+  wallet.publicKey = await wonder.getPublicKey();
+  const balance = await wonder.getBalances();
+  const confirmed = balance?.confirmed ?? 0;
+  const unconfirmed = balance?.unconfirmed ?? 0;
+  wallet.btcBalance = {
+    confirmed,
+    unconfirmed,
+    total: balance?.total ?? confirmed + unconfirmed,
+  };
+  wallet.network = "mainnet";
+  wallet.provider = "wonder";
+  walletContext.updateWallet(wallet);
+};
+
+const wonderForEvents = getProvider();
+wonderForEvents?.on?.("accountsChanged", handleAccountsChanged);
+
+interface WonderSignOptions {
+  autoFinalized: boolean;
+  enableRBF: boolean;
+  toSignInputs?: {
+    index: number;
+    address: string;
+    sighashTypes?: number[] | undefined;
+  }[];
+}
+
+interface WonderSignResult {
+  txhex?: string;
+  txid?: string;
+  psbt?: string;
+}
+
+export const signPSBT = async (
+  psbtHex: string,
+  inputsToSign: { index: number }[],
+  enableRBF = true,
+  sighashTypes?: number[],
+  autoBroadcast = true,
+): Promise<SignPSBTResult> => {
+  try {
+    const wonder = getProvider();
+    if (!wonder) {
+      return { signed: false, error: "Wonder Wallet not connected" };
+    }
+
+    // Wonder is UniSat-style: with autoFinalized it returns the finalized
+    // { txhex, txid }; without it, a signed { psbt }. It only signs the inputs
+    // it owns, so an input map is optional.
+    const options: WonderSignOptions = {
+      autoFinalized: autoBroadcast,
+      enableRBF,
+    };
+    if (inputsToSign?.length > 0) {
+      options.toSignInputs = inputsToSign.map((input) => ({
+        index: input.index,
+        address: walletContext.wallet.address,
+        sighashTypes,
+      }));
+    }
+
+    const rawResult = await wonder.signPsbt(psbtHex, options);
+    const result = rawResult as WonderSignResult | undefined;
+
+    logger.debug("ui", {
+      message: "Wonder signPsbt result",
+      data: { hasTxhex: !!result?.txhex, hasPsbt: !!result?.psbt },
+    });
+
+    if (!result) {
+      return { signed: false, error: "No result from Wonder Wallet" };
+    }
+
+    // autoBroadcast → the finalized txhex is ready to push to the network.
+    if (autoBroadcast && result.txhex) {
+      try {
+        const txid = await wonder.broadcastTransaction(result.txhex);
+        logger.info("ui", {
+          message: "Successfully broadcast transaction",
+          data: { txid },
+        });
+        return { signed: true, txid };
+      } catch (_broadcastError) {
+        return {
+          signed: true,
+          psbt: result.txhex,
+          error: "Transaction signed but broadcast failed",
+        };
+      }
+    }
+
+    // Not broadcasting (or the wallet returned a signed PSBT to broadcast later).
+    if (result.psbt) {
+      return { signed: true, psbt: result.psbt };
+    }
+    if (result.txhex) {
+      return { signed: true, psbt: result.txhex };
+    }
+    return { signed: false, error: "No signed result from Wonder Wallet" };
+  } catch (error: unknown) {
+    return handleWalletError(error, "Wonder");
+  }
+};
+
+export const signMessage = async (message: string): Promise<string> => {
+  const wonder = getProvider();
+  if (!wonder) {
+    throw new Error("Wonder Wallet not connected");
+  }
+  return await wonder.signMessage(message);
+};
+
+// Export the provider
+export const wonderProvider = {
+  connectWonder,
+  signPSBT,
+  signMessage,
+};

--- a/client/wallet/wonder.ts
+++ b/client/wallet/wonder.ts
@@ -7,6 +7,7 @@ import {
   handleWalletError,
   parseConnectionError,
 } from "$client/wallet/walletHelper.ts";
+import { base64ToHex } from "$lib/utils/data/binary/baseUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
 import type { BaseToast } from "$lib/utils/ui/notifications/toastSignal.ts";
 import type { SignPSBTResult, Wallet } from "$types/index.d.ts";
@@ -25,6 +26,37 @@ const getProvider = () => {
   return wallets.wonderWallet;
 };
 
+// requestAccounts resolves { accounts, proof } for a first-time connect
+// approval but a bare string[] once the origin already holds a grant, and the
+// accountsChanged event always emits the bare array.
+const toAccounts = (result: unknown): string[] => {
+  const list = Array.isArray(result)
+    ? result
+    : (result as { accounts?: unknown } | null)?.accounts;
+  return Array.isArray(list)
+    ? list.filter((account): account is string => typeof account === "string")
+    : [];
+};
+
+// broadcastTransaction resolves { txid } through the extension provider.
+const toTxid = (result: unknown): string => {
+  if (typeof result === "string") return result;
+  const txid = (result as { txid?: unknown } | null)?.txid;
+  return typeof txid === "string" ? txid : "";
+};
+
+// Wonder returns a partially signed PSBT as base64; the rest of the app passes
+// PSBTs around as hex.
+const toPsbtHex = (psbt: string): string =>
+  /^[0-9a-fA-F]+$/.test(psbt) ? psbt : base64ToHex(psbt);
+
+const addressTypeFor = (address: string): Wallet["addressType"] => {
+  if (address.startsWith("bc1p")) return "p2tr";
+  if (address.startsWith("bc1")) return "p2wpkh";
+  if (address.startsWith("3")) return "p2sh";
+  return "p2pkh";
+};
+
 export const connectWonder = async (
   addToast: (message: string, type: BaseToast["type"]) => void,
 ) => {
@@ -41,7 +73,18 @@ export const connectWonder = async (
       );
       return;
     }
-    const accounts = await wonder.requestAccounts();
+    const accounts = toAccounts(await wonder.requestAccounts());
+    if (accounts.length === 0) {
+      logger.error("ui", {
+        message: "Wonder Wallet returned no accounts",
+        context: "connectWonder",
+      });
+      addToast(
+        "Wonder Wallet returned no accounts.\nUnlock the wallet and try again.",
+        "error",
+      );
+      return;
+    }
     await handleAccountsChanged(accounts);
     logger.info("ui", {
       message: "Successfully connected to Wonder Wallet",
@@ -62,8 +105,9 @@ export const connectWonder = async (
   }
 };
 
-const handleAccountsChanged = async (accounts: string[]) => {
-  if (!accounts || accounts.length === 0) {
+const handleAccountsChanged = async (rawAccounts: unknown) => {
+  const accounts = toAccounts(rawAccounts);
+  if (accounts.length === 0) {
     walletContext.disconnect();
     return;
   }
@@ -71,10 +115,16 @@ const handleAccountsChanged = async (accounts: string[]) => {
     return;
   }
   const wonder = getProvider();
+  if (!wonder) {
+    walletContext.disconnect();
+    return;
+  }
   const wallet = {} as Wallet;
   wallet.accounts = accounts;
   wallet.address = accounts[0];
-  wallet.publicKey = await wonder.getPublicKey();
+  const publicKey = await wonder.getPublicKey();
+  wallet.publicKey = typeof publicKey === "string" ? publicKey : "";
+  wallet.addressType = addressTypeFor(accounts[0]);
   const balance = await wonder.getBalances();
   const confirmed = balance?.confirmed ?? 0;
   const unconfirmed = balance?.unconfirmed ?? 0;
@@ -85,11 +135,31 @@ const handleAccountsChanged = async (accounts: string[]) => {
   };
   wallet.network = "mainnet";
   wallet.provider = "wonder";
+  wallet.stampBalance = [];
   walletContext.updateWallet(wallet);
 };
 
-const wonderForEvents = getProvider();
-wonderForEvents?.on?.("accountsChanged", handleAccountsChanged);
+const registerProviderEvents = (provider: ReturnType<typeof getProvider>) => {
+  provider?.on?.("accountsChanged", (accounts: unknown) => {
+    void handleAccountsChanged(accounts);
+  });
+  provider?.on?.("disconnect", () => {
+    walletContext.disconnect();
+  });
+};
+
+// Wonder injects at document_start and announces itself with an event, so the
+// provider can still be missing when this module first evaluates.
+const wonderAtLoad = getProvider();
+if (wonderAtLoad) {
+  registerProviderEvents(wonderAtLoad);
+} else if (typeof globalThis.addEventListener === "function") {
+  globalThis.addEventListener(
+    "wonder-wallet#initialized",
+    () => registerProviderEvents(getProvider()),
+    { once: true },
+  );
+}
 
 interface WonderSignOptions {
   autoFinalized: boolean;
@@ -150,7 +220,10 @@ export const signPSBT = async (
     // autoBroadcast → the finalized txhex is ready to push to the network.
     if (autoBroadcast && result.txhex) {
       try {
-        const txid = await wonder.broadcastTransaction(result.txhex);
+        const txid = toTxid(await wonder.broadcastTransaction(result.txhex));
+        if (!txid) {
+          throw new Error("Wonder Wallet did not return a txid");
+        }
         logger.info("ui", {
           message: "Successfully broadcast transaction",
           data: { txid },
@@ -167,7 +240,7 @@ export const signPSBT = async (
 
     // Not broadcasting (or the wallet returned a signed PSBT to broadcast later).
     if (result.psbt) {
-      return { signed: true, psbt: result.psbt };
+      return { signed: true, psbt: toPsbtHex(result.psbt) };
     }
     if (result.txhex) {
       return { signed: true, psbt: result.txhex };
@@ -186,9 +259,37 @@ export const signMessage = async (message: string): Promise<string> => {
   return await wonder.signMessage(message);
 };
 
+export const broadcastRawTX = async (rawTx: string): Promise<string> => {
+  const wonder = getProvider();
+  if (!wonder) {
+    throw new Error("Wonder Wallet not connected");
+  }
+  const txid = toTxid(await wonder.broadcastTransaction(rawTx));
+  if (!txid) {
+    throw new Error("Wonder Wallet did not return a txid");
+  }
+  return txid;
+};
+
+// Wonder has no push-PSBT method. The retry paths only ever hand back the
+// finalized txhex from an autoFinalized sign, so reject anything still carrying
+// the PSBT magic bytes rather than letting the extension fail on it.
+export const broadcastPSBT = async (psbtHex: string): Promise<string> => {
+  if (psbtHex.toLowerCase().startsWith("70736274ff")) {
+    throw new Error(
+      "Wonder Wallet cannot broadcast an unfinalized PSBT. " +
+        "Re-sign the transaction to broadcast it.",
+    );
+  }
+  return await broadcastRawTX(psbtHex);
+};
+
 // Export the provider
 export const wonderProvider = {
+  checkWonder,
   connectWonder,
   signPSBT,
   signMessage,
+  broadcastRawTX,
+  broadcastPSBT,
 };

--- a/fresh.config.ts
+++ b/fresh.config.ts
@@ -1,6 +1,22 @@
-import { defineConfig } from "$fresh/server.ts";
 import tailwind from "$fresh/plugins/tailwind.ts";
+import { defineConfig } from "$fresh/server.ts";
+import { LOCAL_HTTPS } from "$lib/utils/dataPlaceholderProd.ts";
+
+function localHttpsServer(): { cert?: string; key?: string } {
+  if (!LOCAL_HTTPS) return {};
+  try {
+    return {
+      cert: Deno.readTextFileSync("./localhost-cert.pem"),
+      key: Deno.readTextFileSync("./localhost-key.pem"),
+    };
+  } catch {
+    throw new Error(
+      "LOCAL_HTTPS is true but localhost-cert.pem / localhost-key.pem are missing.",
+    );
+  }
+}
 
 export default defineConfig({
   plugins: [tailwind()],
+  server: localHttpsServer(),
 });

--- a/islands/layout/WalletProvider.tsx
+++ b/islands/layout/WalletProvider.tsx
@@ -6,6 +6,7 @@ import { phantomProvider } from "$client/wallet/phantom.ts";
 import { tapWalletProvider } from "$client/wallet/tapwallet.ts";
 import { unisatProvider } from "$client/wallet/unisat.ts";
 import { checkWalletAvailability } from "$client/wallet/wallet.ts";
+import { wonderProvider } from "$client/wallet/wonder.ts";
 import { xverseProvider } from "$client/wallet/xverse.ts";
 import { WALLET_PROVIDERS } from "$constants";
 import { closeForegroundModal, closeModal } from "$islands/modal/states.ts";
@@ -35,6 +36,7 @@ const walletConnectors: Record<
   phantom: phantomProvider.connectPhantom,
   horizon: horizonProvider.connectHorizon,
   xverse: xverseProvider.connectXverse,
+  wonder: wonderProvider.connectWonder,
 } as const;
 
 /* ===== MODAL COMPONENT ===== */

--- a/lib/constants/walletProviders.ts
+++ b/lib/constants/walletProviders.ts
@@ -10,7 +10,8 @@ export type WalletProviderKey =
   | "tapwallet"
   | "phantom"
   | "horizon"
-  | "xverse";
+  | "xverse"
+  | "wonder";
 
 /**
  * Default wallet connectors available in the application
@@ -23,6 +24,7 @@ export const DEFAULT_WALLET_CONNECTORS: WalletProviderKey[] = [
   "phantom",
   "horizon",
   "xverse",
+  "wonder",
 ];
 
 /**
@@ -104,6 +106,21 @@ export const WALLET_PROVIDERS: Record<WalletProviderKey, WalletProviderConfig> =
       installUrl:
         "https://chromewebstore.google.com/detail/xverse-wallet/idnnbdplmphpflfnlkomgpfbpcgelopg",
       capabilities: ["p2tr", "p2wpkh", "psbt", "message-signing", "send-btc"],
+      addressTypes: ["payment", "ordinals"],
+    },
+    wonder: {
+      name: "Wonder",
+      logo: "/img/wallet/wonder/logo_wonder.svg",
+      installUrl: "https://wonder-wallet.com",
+      capabilities: [
+        "p2tr",
+        "p2wpkh",
+        "p2sh",
+        "p2pkh",
+        "psbt",
+        "message-signing",
+        "send-btc",
+      ],
       addressTypes: ["payment", "ordinals"],
     },
   };

--- a/lib/types/wallet.d.ts
+++ b/lib/types/wallet.d.ts
@@ -531,7 +531,8 @@ export type StandardWalletProvider =
   | "xverse"
   | "hiro"
   | "leather"
-  | "phantom";
+  | "phantom"
+  | "wonder";
 
 /**
  * Base wallet provider interface that all providers must implement
@@ -738,11 +739,41 @@ export interface LeatherWalletAPI extends BaseWalletProvider {
 /**
  * Union type of all specific wallet APIs
  */
+/**
+ * Wonder Wallet injected provider (window.wonderWallet)
+ *
+ * requestAccounts resolves { accounts, proof } on a first-time grant and a
+ * bare string[] on a repeat connect. broadcastTransaction resolves { txid }.
+ * signPsbt returns { txhex, txid } when autoFinalized, else { psbt } (base64).
+ */
+export interface WonderWalletAPI {
+  isWonderWallet?: boolean;
+  requestAccounts(): Promise<
+    string[] | { accounts?: string[]; proof?: unknown }
+  >;
+  getAccounts(): Promise<string[]>;
+  getPublicKey(): Promise<string | null>;
+  getBalances(): Promise<
+    { confirmed?: number; unconfirmed?: number; total?: number }
+  >;
+  signMessage(message: string, address?: string): Promise<string>;
+  signPsbt(
+    psbtHex: string,
+    options?: any,
+  ): Promise<{ txhex?: string; txid?: string; psbt?: string }>;
+  broadcastTransaction(
+    hex: string,
+  ): Promise<string | { txid?: string }>;
+  on(event: string, handler: (payload?: unknown) => void): void;
+  removeListener?(event: string, handler: (payload?: unknown) => void): void;
+}
+
 export type WalletAPI =
   | UnisatWalletAPI
   | XverseWalletAPI
   | HiroWalletAPI
-  | LeatherWalletAPI;
+  | LeatherWalletAPI
+  | WonderWalletAPI;
 
 /**
  * Wallet provider factory interface
@@ -778,6 +809,9 @@ declare global {
 
     // Existing Horizon wallet (already defined above)
     HorizonWalletProvider?: HorizonWalletAPI;
+
+    // Wonder Wallet
+    wonderWallet?: WonderWalletAPI;
   }
 }
 

--- a/lib/utils/bitcoin/psbt/psbtUtils.ts
+++ b/lib/utils/bitcoin/psbt/psbtUtils.ts
@@ -84,6 +84,43 @@ export function extractRawTransactionFromPSBT(psbtHex: string): string | null {
 }
 
 /**
+ * Extracts the previous transactions embedded on a PSBT's inputs as
+ * `nonWitnessUtxo`, keyed by their (display) txid.
+ *
+ * Legacy (non-witness / P2PKH, P2SH) inputs require the full previous
+ * transaction to be signed. stampchain's transaction builders already embed it
+ * as `nonWitnessUtxo` on each such input, but wallets that want it as a separate
+ * `prevTxs` map (e.g. Wonder Wallet's `signPsbt({ prevTxs })`) can't read it off
+ * the PSBT directly. This pulls it out so it can be handed to them, with no
+ * extra round-trip. SegWit inputs carry `witnessUtxo` instead and are skipped.
+ *
+ * @param psbtHex - The PSBT in hex format
+ * @returns A map of `{ [txid]: rawTxHex }` for every non-witness input; empty
+ *          when the PSBT is SegWit-only or cannot be parsed.
+ */
+export function extractPrevTxsFromPSBT(
+  psbtHex: string,
+): Record<string, string> {
+  const prevTxs: Record<string, string> = {};
+  try {
+    const psbt = bitcoin.Psbt.fromHex(psbtHex);
+    for (const input of psbt.data.inputs) {
+      if (!input.nonWitnessUtxo) continue;
+      const prevTx = bitcoin.Transaction.fromBuffer(input.nonWitnessUtxo);
+      // getId() is the display (big-endian) txid, which is the key wallets and
+      // block explorers use.
+      prevTxs[prevTx.getId()] = prevTx.toHex();
+    }
+  } catch (error) {
+    logger.warn("psbt", {
+      message: "Failed to extract prevTxs from PSBT",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return prevTxs;
+}
+
+/**
  * Checks if a hex string is a PSBT by looking for magic bytes
  *
  * @param hex - The hex string to check

--- a/lib/utils/dataPlaceholderProd.ts
+++ b/lib/utils/dataPlaceholderProd.ts
@@ -10,6 +10,12 @@ import type { StampRow } from "$types/stamp.d.ts";
  *
  * Flip to true when developing UI without a database connection.
  *
+ * LOCAL_HTTPS (default: false)
+ *   false → Fresh listens on http://localhost:8000
+ *   true  → Fresh listens on https://localhost:8000 using
+ *           ./localhost-cert.pem and ./localhost-key.pem
+ *           (generate once with openssl; do not commit the pem files)
+ *
  * Everything in this file is small, dependency-free, and always loaded —
  * safe to statically import from any route. The rich dev-only dataset
  * lives in dataPlaceholderDev.ts and must only ever be reached via a
@@ -22,6 +28,7 @@ import type { StampRow } from "$types/stamp.d.ts";
  * strings, not fake stamp or token content.
  */
 export const DATA_PLACEHOLDER_DEV = false;
+export const LOCAL_HTTPS = false;
 
 /* ===== HOME PAGE (routes/index.tsx) ===== */
 export const DATA_PLACEHOLDER_PROD_HOME = {

--- a/lib/utils/typeGuards.ts
+++ b/lib/utils/typeGuards.ts
@@ -1090,7 +1090,9 @@ export function isValidWalletProvider(
 ): provider is WalletProviderKey {
   return (
     typeof provider === "string" &&
-    ["unisat", "xverse", "hiro", "leather", "horizon"].includes(provider)
+    ["unisat", "xverse", "hiro", "leather", "horizon", "wonder"].includes(
+      provider,
+    )
   );
 }
 

--- a/static/img/wallet/wonder/logo_wonder.svg
+++ b/static/img/wallet/wonder/logo_wonder.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Wonder Wallet">
+  <rect width="128" height="128" rx="30" fill="#0a0a0f"/>
+  <defs>
+    <radialGradient id="wonderGold" cx="50%" cy="34%" r="72%">
+      <stop offset="0%" stop-color="#F4D58D"/>
+      <stop offset="55%" stop-color="#E0B453"/>
+      <stop offset="100%" stop-color="#9a6f1f"/>
+    </radialGradient>
+  </defs>
+  <circle cx="64" cy="64" r="45" fill="url(#wonderGold)"/>
+  <circle cx="64" cy="64" r="45" fill="none" stroke="#000" stroke-opacity="0.18" stroke-width="2"/>
+  <path d="M40 46 L52 84 L64 58 L76 84 L88 46" fill="none" stroke="#3a2606" stroke-width="7" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -138,6 +138,7 @@ Deno.test("constants - wallet providers", () => {
     "phantom",
     "horizon",
     "xverse",
+    "wonder",
   ];
 
   assertEquals(

--- a/tests/unit/psbtUtils.prevtxs.test.ts
+++ b/tests/unit/psbtUtils.prevtxs.test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from "@std/assert";
+import * as bitcoin from "bitcoinjs-lib";
+import { extractPrevTxsFromPSBT } from "$lib/utils/bitcoin/psbt/psbtUtils.ts";
+
+// A minimal P2PKH-style output script (OP_DUP OP_HASH160 <20> OP_EQUALVERIFY
+// OP_CHECKSIG) — enough to stand in for a legacy previous output.
+const p2pkhScript = bitcoin.script.compile([
+  bitcoin.opcodes.OP_DUP,
+  bitcoin.opcodes.OP_HASH160,
+  new Uint8Array(20),
+  bitcoin.opcodes.OP_EQUALVERIFY,
+  bitcoin.opcodes.OP_CHECKSIG,
+]);
+
+function buildPrevTx(): bitcoin.Transaction {
+  const prevTx = new bitcoin.Transaction();
+  prevTx.version = 2;
+  prevTx.addInput(new Uint8Array(32), 0xffffffff);
+  prevTx.addOutput(p2pkhScript, 100_000n);
+  return prevTx;
+}
+
+Deno.test("extractPrevTxsFromPSBT - legacy input, keyed by display txid", () => {
+  const prevTx = buildPrevTx();
+  const psbt = new bitcoin.Psbt();
+  psbt.addInput({
+    hash: prevTx.getId(),
+    index: 0,
+    nonWitnessUtxo: prevTx.toBuffer(),
+  });
+  psbt.addOutput({ script: p2pkhScript, value: 90_000n });
+
+  const prevTxs = extractPrevTxsFromPSBT(psbt.toHex());
+
+  assertEquals(Object.keys(prevTxs).length, 1);
+  assertEquals(prevTxs[prevTx.getId()], prevTx.toHex());
+});
+
+Deno.test("extractPrevTxsFromPSBT - segwit-only PSBT yields an empty map", () => {
+  const psbt = new bitcoin.Psbt();
+  psbt.addInput({
+    hash: new Uint8Array(32),
+    index: 0,
+    witnessUtxo: { script: p2pkhScript, value: 100_000n },
+  });
+  psbt.addOutput({ script: p2pkhScript, value: 90_000n });
+
+  assertEquals(extractPrevTxsFromPSBT(psbt.toHex()), {});
+});
+
+Deno.test("extractPrevTxsFromPSBT - unparseable input returns an empty map", () => {
+  assertEquals(extractPrevTxsFromPSBT("not-a-psbt"), {});
+});

--- a/tests/unit/wallet/wonder.adapter.test.ts
+++ b/tests/unit/wallet/wonder.adapter.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Tests that exercise the REAL client/wallet/wonder.ts module.
+ *
+ * tests/unit/wallet/wonder.test.ts covers the adapter's logic through local
+ * mirror implementations. That protects the intended behaviour but never
+ * executes wonder.ts itself, so a regression in the shipped module would go
+ * unnoticed and the file reports ~12% coverage. This suite imports the real
+ * adapter and drives it with a stubbed `window.wonderWallet`.
+ *
+ * Import order matters: wallet.ts -> ModalStack.tsx -> WalletProvider.tsx ->
+ * wonder.ts -> wallet.ts is a cycle. The browser always enters that cycle from
+ * an island, so we import the island first to reproduce the same evaluation
+ * order; importing wonder.ts as the entry module trips a TDZ error inside
+ * WalletProvider.tsx.
+ */
+
+import "$islands/layout/WalletProvider.tsx";
+import { assertEquals, assertRejects } from "@std/assert";
+import * as bitcoin from "bitcoinjs-lib";
+import {
+  initialWallet,
+  isConnectedSignal,
+  walletContext,
+  walletSignal,
+} from "$client/wallet/wallet.ts";
+import {
+  broadcastPSBT,
+  broadcastRawTX,
+  checkWonder,
+  connectWonder,
+  isWonderInstalled,
+  signMessage,
+  signPSBT,
+  wonderProvider,
+} from "$client/wallet/wonder.ts";
+import { hexToBase64 } from "$lib/utils/data/binary/baseUtils.ts";
+
+// ============================================================================
+// Stub provider + global installation helpers
+// ============================================================================
+
+type Handler = (payload?: unknown) => void;
+
+interface StubProvider {
+  requestAccounts: () => Promise<unknown>;
+  getPublicKey: () => Promise<string | null>;
+  getBalances: () => Promise<
+    { confirmed?: number; unconfirmed?: number; total?: number } | undefined
+  >;
+  signPsbt: (psbtHex: string, options: unknown) => Promise<unknown>;
+  broadcastTransaction: (txhex: string) => Promise<unknown>;
+  signMessage: (message: string) => Promise<string>;
+  on: (event: string, handler: Handler) => void;
+  handlers: Record<string, Handler[]>;
+  calls: { signPsbt: unknown[][]; broadcast: string[] };
+}
+
+const ADDRESS = "bc1qwonderpayment123abc";
+const ADDRESS_2 = "bc1qwondersecondaccount";
+const PUBKEY = "02wonderpubkey1234567890abcdef";
+const PSBT_MAGIC_HEX = "70736274ff01000a0200000000000000000000";
+
+function buildStub(overrides: Partial<StubProvider> = {}): StubProvider {
+  const stub: StubProvider = {
+    requestAccounts: () =>
+      Promise.resolve({ accounts: [ADDRESS], proof: { signature: "s" } }),
+    getPublicKey: () => Promise.resolve(PUBKEY),
+    getBalances: () =>
+      Promise.resolve({
+        confirmed: 100_000,
+        unconfirmed: 5_000,
+        total: 105_000,
+      }),
+    signPsbt: (psbtHex, options) => {
+      stub.calls.signPsbt.push([psbtHex, options]);
+      return Promise.resolve({ txhex: "aabbcc", txid: "signedtxid" });
+    },
+    broadcastTransaction: (txhex) => {
+      stub.calls.broadcast.push(txhex);
+      return Promise.resolve({ txid: "broadcasttxid" });
+    },
+    signMessage: () => Promise.resolve("signature123"),
+    on: (event, handler) => {
+      (stub.handlers[event] ??= []).push(handler);
+    },
+    handlers: {},
+    calls: { signPsbt: [], broadcast: [] },
+    ...overrides,
+  };
+  return stub;
+}
+
+type WalletGlobals = {
+  document?: unknown;
+  wonderWallet?: StubProvider;
+};
+
+const globals = globalThis as unknown as WalletGlobals;
+
+/** getGlobalWallets() only inspects window.* when a `document` exists. */
+function installProvider(stub: StubProvider | undefined): void {
+  globals.document = {};
+  if (stub) {
+    globals.wonderWallet = stub;
+  } else {
+    delete globals.wonderWallet;
+  }
+}
+
+/**
+ * Resets wallet state without walletContext.disconnect(), whose toast starts a
+ * 50 ms timer that would trip Deno's op sanitizer.
+ */
+function uninstallProvider(): void {
+  delete globals.document;
+  delete globals.wonderWallet;
+  walletSignal.value = initialWallet;
+  isConnectedSignal.value = false;
+  localStorage.removeItem("wallet");
+}
+
+/** Lets showToast's 50 ms auto-clear timer finish (adapter-driven disconnects). */
+const settleToasts = () => new Promise((resolve) => setTimeout(resolve, 60));
+
+function toastRecorder() {
+  const toasts: { message: string; type: string }[] = [];
+  const addToast = (message: string, type: string) => {
+    toasts.push({ message, type });
+  };
+  return { toasts, addToast };
+}
+
+/** Runs `fn` with the stub installed and always restores globals afterwards. */
+async function withProvider(
+  stub: StubProvider | undefined,
+  fn: (stub: StubProvider | undefined) => Promise<void> | void,
+): Promise<void> {
+  installProvider(stub);
+  try {
+    await fn(stub);
+  } finally {
+    uninstallProvider();
+  }
+}
+
+function buildLegacyPsbt(): { psbtHex: string; prevTxid: string } {
+  const p2pkhScript = bitcoin.script.compile([
+    bitcoin.opcodes.OP_DUP,
+    bitcoin.opcodes.OP_HASH160,
+    new Uint8Array(20),
+    bitcoin.opcodes.OP_EQUALVERIFY,
+    bitcoin.opcodes.OP_CHECKSIG,
+  ]);
+  const prevTx = new bitcoin.Transaction();
+  prevTx.version = 2;
+  prevTx.addInput(new Uint8Array(32), 0xffffffff);
+  prevTx.addOutput(p2pkhScript, 100_000n);
+
+  const psbt = new bitcoin.Psbt();
+  psbt.addInput({
+    hash: prevTx.getId(),
+    index: 0,
+    nonWitnessUtxo: prevTx.toBuffer(),
+  });
+  psbt.addOutput({ script: p2pkhScript, value: 90_000n });
+  return { psbtHex: psbt.toHex(), prevTxid: prevTx.getId() };
+}
+
+function buildSegwitPsbt(): string {
+  const script = bitcoin.script.compile([
+    bitcoin.opcodes.OP_0,
+    new Uint8Array(20),
+  ]);
+  const psbt = new bitcoin.Psbt();
+  psbt.addInput({
+    hash: new Uint8Array(32),
+    index: 0,
+    witnessUtxo: { script, value: 100_000n },
+  });
+  psbt.addOutput({ script, value: 90_000n });
+  return psbt.toHex();
+}
+
+// ============================================================================
+// wonderProvider surface
+// ============================================================================
+
+Deno.test("wonderProvider exposes the adapter surface used by walletHelper", () => {
+  assertEquals(Object.keys(wonderProvider).sort(), [
+    "broadcastPSBT",
+    "broadcastRawTX",
+    "checkWonder",
+    "connectWonder",
+    "signMessage",
+    "signPSBT",
+  ]);
+  assertEquals(wonderProvider.signPSBT, signPSBT);
+  assertEquals(wonderProvider.connectWonder, connectWonder);
+});
+
+// ============================================================================
+// checkWonder
+// ============================================================================
+
+Deno.test("checkWonder: false and signal cleared when no provider is injected", async () => {
+  await withProvider(undefined, () => {
+    assertEquals(checkWonder(), false);
+    assertEquals(isWonderInstalled.value, false);
+  });
+});
+
+Deno.test("checkWonder: true and signal set when window.wonderWallet exists", async () => {
+  await withProvider(buildStub(), () => {
+    assertEquals(checkWonder(), true);
+    assertEquals(isWonderInstalled.value, true);
+  });
+});
+
+// ============================================================================
+// connectWonder
+// ============================================================================
+
+Deno.test("connectWonder: toasts an install error when the provider is missing", async () => {
+  await withProvider(undefined, async () => {
+    const { toasts, addToast } = toastRecorder();
+    await connectWonder(addToast);
+    assertEquals(toasts.length, 1);
+    assertEquals(toasts[0].type, "error");
+    assertEquals(toasts[0].message.includes("not detected"), true);
+    assertEquals(walletContext.isConnected, false);
+  });
+});
+
+Deno.test("connectWonder: populates walletContext from the { accounts, proof } response", async () => {
+  await withProvider(buildStub(), async () => {
+    const { toasts, addToast } = toastRecorder();
+    await connectWonder(addToast);
+
+    assertEquals(toasts, [
+      { message: "Connected using Wonder Wallet.", type: "success" },
+    ]);
+    const wallet = walletContext.wallet;
+    assertEquals(wallet.address, ADDRESS);
+    assertEquals(wallet.accounts, [ADDRESS]);
+    assertEquals(wallet.publicKey, PUBKEY);
+    assertEquals(wallet.provider, "wonder");
+    assertEquals(wallet.network, "mainnet");
+    assertEquals(wallet.addressType, "p2wpkh");
+    assertEquals(wallet.stampBalance, []);
+    assertEquals(wallet.btcBalance, {
+      confirmed: 100_000,
+      unconfirmed: 5_000,
+      total: 105_000,
+    });
+    assertEquals(walletContext.isConnected, true);
+  });
+});
+
+Deno.test("connectWonder: accepts the bare string[] repeat-connect response", async () => {
+  const stub = buildStub({
+    requestAccounts: () => Promise.resolve([ADDRESS_2]),
+  });
+  await withProvider(stub, async () => {
+    const { toasts, addToast } = toastRecorder();
+    await connectWonder(addToast);
+    assertEquals(toasts[0].type, "success");
+    assertEquals(walletContext.wallet.address, ADDRESS_2);
+  });
+});
+
+Deno.test("connectWonder: derives addressType from the address prefix", async () => {
+  const cases: [string, string][] = [
+    ["bc1pwondertaproot", "p2tr"],
+    ["bc1qwondersegwit", "p2wpkh"],
+    ["3WonderNestedSegwit", "p2sh"],
+    ["1WonderLegacy", "p2pkh"],
+  ];
+  for (const [address, expected] of cases) {
+    const stub = buildStub({
+      requestAccounts: () => Promise.resolve([address]),
+    });
+    await withProvider(stub, async () => {
+      await connectWonder(() => {});
+      assertEquals(walletContext.wallet.addressType, expected);
+    });
+  }
+});
+
+Deno.test("connectWonder: falls back to empty publicKey and summed total balance", async () => {
+  const stub = buildStub({
+    getPublicKey: () => Promise.resolve(null),
+    getBalances: () => Promise.resolve({ confirmed: 7, unconfirmed: 3 }),
+  });
+  await withProvider(stub, async () => {
+    await connectWonder(() => {});
+    assertEquals(walletContext.wallet.publicKey, "");
+    assertEquals(walletContext.wallet.btcBalance, {
+      confirmed: 7,
+      unconfirmed: 3,
+      total: 10,
+    });
+  });
+});
+
+Deno.test("connectWonder: zeroes the balance when getBalances resolves undefined", async () => {
+  const stub = buildStub({ getBalances: () => Promise.resolve(undefined) });
+  await withProvider(stub, async () => {
+    await connectWonder(() => {});
+    assertEquals(walletContext.wallet.btcBalance, {
+      confirmed: 0,
+      unconfirmed: 0,
+      total: 0,
+    });
+  });
+});
+
+Deno.test("connectWonder: reports an error instead of a false success on zero accounts", async () => {
+  const stub = buildStub({
+    requestAccounts: () => Promise.resolve({ accounts: [], proof: {} }),
+  });
+  await withProvider(stub, async () => {
+    const { toasts, addToast } = toastRecorder();
+    await connectWonder(addToast);
+    assertEquals(toasts.length, 1);
+    assertEquals(toasts[0].type, "error");
+    assertEquals(toasts[0].message.includes("no accounts"), true);
+    assertEquals(walletContext.isConnected, false);
+  });
+});
+
+Deno.test("connectWonder: surfaces a rejected approval as an error toast", async () => {
+  const stub = buildStub({
+    requestAccounts: () => Promise.reject(new Error("User rejected request")),
+  });
+  await withProvider(stub, async () => {
+    const { toasts, addToast } = toastRecorder();
+    await connectWonder(addToast);
+    assertEquals(toasts.length, 1);
+    assertEquals(toasts[0].type, "error");
+    assertEquals(toasts[0].message.startsWith("Failed to connect"), true);
+    assertEquals(walletContext.isConnected, false);
+  });
+});
+
+// ============================================================================
+// Provider events (accountsChanged / disconnect) via wonder-wallet#initialized
+// ============================================================================
+
+Deno.test("provider events: late-injected provider gets accountsChanged and disconnect wired", async () => {
+  const stub = buildStub();
+  await withProvider(stub, async () => {
+    // The module registered a one-shot listener at import time because no
+    // provider existed then; announcing the provider wires the handlers.
+    globalThis.dispatchEvent(new Event("wonder-wallet#initialized"));
+    const accountsChanged = stub.handlers["accountsChanged"]?.[0];
+    const disconnect = stub.handlers["disconnect"]?.[0];
+    assertEquals(typeof accountsChanged, "function");
+    assertEquals(typeof disconnect, "function");
+
+    // Switching to a new account updates the wallet.
+    accountsChanged?.([ADDRESS_2]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(walletContext.wallet.address, ADDRESS_2);
+    assertEquals(walletContext.isConnected, true);
+
+    // Same account again is a no-op (no re-fetch, still connected).
+    accountsChanged?.([ADDRESS_2]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(walletContext.wallet.address, ADDRESS_2);
+
+    // An empty account list disconnects.
+    accountsChanged?.([]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(walletContext.isConnected, false);
+
+    // Reconnect, then the provider's disconnect event tears it down.
+    accountsChanged?.([ADDRESS]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(walletContext.isConnected, true);
+    disconnect?.();
+    assertEquals(walletContext.isConnected, false);
+    await settleToasts();
+  });
+});
+
+// ============================================================================
+// signPSBT
+// ============================================================================
+
+Deno.test("signPSBT: returns an error when the provider is missing", async () => {
+  await withProvider(undefined, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, [{ index: 0 }]);
+    assertEquals(result, {
+      signed: false,
+      error: "Wonder Wallet not connected",
+    });
+  });
+});
+
+Deno.test("signPSBT: auto-broadcast unwraps { txid } from broadcastTransaction", async () => {
+  const stub = buildStub();
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, [{ index: 0 }]);
+    assertEquals(result, { signed: true, txid: "broadcasttxid" });
+    assertEquals(stub.calls.broadcast, ["aabbcc"]);
+  });
+});
+
+Deno.test("signPSBT: auto-broadcast accepts a bare string txid", async () => {
+  const stub = buildStub({
+    broadcastTransaction: () => Promise.resolve("plaintxid"),
+  });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, []);
+    assertEquals(result, { signed: true, txid: "plaintxid" });
+  });
+});
+
+Deno.test("signPSBT: passes autoFinalized, enableRBF and mapped toSignInputs to the wallet", async () => {
+  const stub = buildStub();
+  await withProvider(stub, async () => {
+    await connectWonder(() => {});
+    stub.calls.signPsbt.length = 0;
+    await signPSBT(PSBT_MAGIC_HEX, [{ index: 0 }, { index: 2 }], false, [1]);
+    assertEquals(stub.calls.signPsbt.length, 1);
+    const [psbtArg, options] = stub.calls.signPsbt[0] as [string, {
+      autoFinalized: boolean;
+      enableRBF: boolean;
+      toSignInputs?: unknown;
+      prevTxs?: unknown;
+    }];
+    assertEquals(psbtArg, PSBT_MAGIC_HEX);
+    assertEquals(options.autoFinalized, true);
+    assertEquals(options.enableRBF, false);
+    assertEquals(options.toSignInputs, [
+      { index: 0, address: ADDRESS, sighashTypes: [1] },
+      { index: 2, address: ADDRESS, sighashTypes: [1] },
+    ]);
+    assertEquals("prevTxs" in options, false);
+  });
+});
+
+Deno.test("signPSBT: omits toSignInputs when no inputs are given", async () => {
+  const stub = buildStub();
+  await withProvider(stub, async () => {
+    await signPSBT(PSBT_MAGIC_HEX, []);
+    const options = stub.calls.signPsbt[0][1] as { toSignInputs?: unknown };
+    assertEquals("toSignInputs" in options, false);
+  });
+});
+
+Deno.test("signPSBT: hands legacy previous transactions to the wallet as prevTxs", async () => {
+  const stub = buildStub();
+  const { psbtHex, prevTxid } = buildLegacyPsbt();
+  await withProvider(stub, async () => {
+    await signPSBT(psbtHex, [{ index: 0 }]);
+    const options = stub.calls.signPsbt[0][1] as {
+      prevTxs?: Record<string, string>;
+    };
+    assertEquals(Object.keys(options.prevTxs ?? {}), [prevTxid]);
+    assertEquals(typeof options.prevTxs?.[prevTxid], "string");
+  });
+});
+
+Deno.test("signPSBT: segwit-only PSBT sends no prevTxs", async () => {
+  const stub = buildStub();
+  await withProvider(stub, async () => {
+    await signPSBT(buildSegwitPsbt(), [{ index: 0 }]);
+    const options = stub.calls.signPsbt[0][1] as { prevTxs?: unknown };
+    assertEquals("prevTxs" in options, false);
+  });
+});
+
+Deno.test("signPSBT: broadcast failure falls back to signed txhex with an error", async () => {
+  const stub = buildStub({
+    broadcastTransaction: () => Promise.reject(new Error("mempool rejected")),
+  });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, []);
+    assertEquals(result, {
+      signed: true,
+      psbt: "aabbcc",
+      error: "Transaction signed but broadcast failed",
+    });
+  });
+});
+
+Deno.test("signPSBT: broadcast response without a txid is treated as a failed broadcast", async () => {
+  const stub = buildStub({
+    broadcastTransaction: () => Promise.resolve({}),
+  });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, []);
+    assertEquals(result, {
+      signed: true,
+      psbt: "aabbcc",
+      error: "Transaction signed but broadcast failed",
+    });
+  });
+});
+
+Deno.test("signPSBT: undefined wallet result is reported as an error", async () => {
+  const stub = buildStub({ signPsbt: () => Promise.resolve(undefined) });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, []);
+    assertEquals(result, {
+      signed: false,
+      error: "No result from Wonder Wallet",
+    });
+  });
+});
+
+Deno.test("signPSBT: non-broadcast path converts a base64 PSBT to hex", async () => {
+  const signedHex = "70736274ff0100";
+  const stub = buildStub({
+    signPsbt: () => Promise.resolve({ psbt: hexToBase64(signedHex) }),
+  });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, [], true, undefined, false);
+    assertEquals(result, { signed: true, psbt: signedHex });
+    assertEquals(stub.calls.broadcast, []);
+  });
+});
+
+Deno.test("signPSBT: non-broadcast path passes a hex PSBT through unchanged", async () => {
+  const stub = buildStub({
+    signPsbt: () => Promise.resolve({ psbt: "70736274FF0100" }),
+  });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, [], true, undefined, false);
+    assertEquals(result, { signed: true, psbt: "70736274FF0100" });
+  });
+});
+
+Deno.test("signPSBT: non-broadcast path returns finalized txhex as psbt when no psbt is given", async () => {
+  const stub = buildStub({
+    signPsbt: () => Promise.resolve({ txhex: "ddeeff" }),
+  });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, [], true, undefined, false);
+    assertEquals(result, { signed: true, psbt: "ddeeff" });
+    assertEquals(stub.calls.broadcast, []);
+  });
+});
+
+Deno.test("signPSBT: empty wallet result is an error", async () => {
+  const stub = buildStub({ signPsbt: () => Promise.resolve({}) });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, []);
+    assertEquals(result, {
+      signed: false,
+      error: "No signed result from Wonder Wallet",
+    });
+  });
+});
+
+Deno.test("signPSBT: wallet rejection is normalised through handleWalletError", async () => {
+  const stub = buildStub({
+    signPsbt: () => Promise.reject(new Error("sighash_not_allowed:0x02")),
+  });
+  await withProvider(stub, async () => {
+    const result = await signPSBT(PSBT_MAGIC_HEX, []);
+    assertEquals(result.signed, false);
+    assertEquals(result.error, "sighash_not_allowed:0x02");
+  });
+});
+
+// ============================================================================
+// signMessage / broadcastRawTX / broadcastPSBT
+// ============================================================================
+
+Deno.test("signMessage: throws without a provider and returns the signature with one", async () => {
+  await withProvider(undefined, async () => {
+    await assertRejects(
+      () => signMessage("hello"),
+      Error,
+      "Wonder Wallet not connected",
+    );
+  });
+  await withProvider(buildStub(), async () => {
+    assertEquals(await signMessage("hello"), "signature123");
+  });
+});
+
+Deno.test("broadcastRawTX: unwraps { txid } and rejects an empty response", async () => {
+  await withProvider(undefined, async () => {
+    await assertRejects(
+      () => broadcastRawTX("aabb"),
+      Error,
+      "Wonder Wallet not connected",
+    );
+  });
+  await withProvider(buildStub(), async () => {
+    assertEquals(await broadcastRawTX("aabb"), "broadcasttxid");
+  });
+  await withProvider(
+    buildStub({ broadcastTransaction: () => Promise.resolve({ txid: 42 }) }),
+    async () => {
+      await assertRejects(
+        () => broadcastRawTX("aabb"),
+        Error,
+        "did not return a txid",
+      );
+    },
+  );
+});
+
+Deno.test("broadcastPSBT: rejects PSBT magic bytes and forwards raw transactions", async () => {
+  const stub = buildStub();
+  await withProvider(stub, async () => {
+    await assertRejects(
+      () => broadcastPSBT(PSBT_MAGIC_HEX),
+      Error,
+      "cannot broadcast an unfinalized PSBT",
+    );
+    await assertRejects(
+      () => broadcastPSBT(PSBT_MAGIC_HEX.toUpperCase()),
+      Error,
+      "cannot broadcast an unfinalized PSBT",
+    );
+    assertEquals(stub.calls.broadcast, []);
+    assertEquals(await broadcastPSBT("0200000001aabb"), "broadcasttxid");
+    assertEquals(stub.calls.broadcast, ["0200000001aabb"]);
+  });
+});

--- a/tests/unit/wallet/wonder.test.ts
+++ b/tests/unit/wallet/wonder.test.ts
@@ -3,8 +3,10 @@
  *
  * Tests cover:
  *   - checkWonder() provider detection
+ *   - connectWonder() account normalization and empty-account handling
  *   - handleAccountsChanged() account/balance mapping and disconnect handling
  *   - signPSBT() PSBT signing with the Wonder (UniSat-style) API
+ *   - broadcastRawTX() / broadcastPSBT() txid unwrapping
  *   - signMessage() message signing
  *   - wonderProvider object structure and interface compliance
  *
@@ -13,9 +15,18 @@
  * Deno server-side test environment. Mocks mirror the exact logic in wonder.ts
  * to validate behavior independently — the same approach used by
  * tests/unit/wallet/xverse.test.ts.
+ *
+ * The provider response shapes exercised here follow the Wonder Wallet
+ * provider API: requestAccounts() resolves { accounts, proof } on a first
+ * connect and a bare string[] on a repeat connect, broadcastTransaction()
+ * resolves { txid }, and a non-finalized signPsbt() resolves a base64 PSBT.
  */
 
 import { assertEquals, assertRejects } from "@std/assert";
+import {
+  base64ToHex,
+  hexToBase64,
+} from "$lib/utils/data/binary/baseUtils.ts";
 
 // ============================================================================
 // Type definitions mirroring the Wonder provider + wallet types
@@ -27,17 +38,29 @@ interface MockBalance {
   total?: number;
 }
 
+type WonderAccountsResponse =
+  | string[]
+  | { accounts?: unknown; proof?: unknown }
+  | null
+  | undefined;
+
+type WonderBroadcastResponse =
+  | string
+  | { txid?: unknown }
+  | null
+  | undefined;
+
 interface MockWonderProvider {
-  requestAccounts: () => Promise<string[]>;
-  getPublicKey: () => Promise<string>;
+  requestAccounts: () => Promise<WonderAccountsResponse>;
+  getPublicKey: () => Promise<string | null>;
   getBalances: () => Promise<MockBalance | undefined>;
   signPsbt: (
     psbtHex: string,
     options: WonderSignOptions,
   ) => Promise<WonderSignResult | undefined>;
-  broadcastTransaction: (txhex: string) => Promise<string>;
+  broadcastTransaction: (txhex: string) => Promise<WonderBroadcastResponse>;
   signMessage: (message: string) => Promise<string>;
-  on?: (event: string, handler: (accounts: string[]) => void) => void;
+  on?: (event: string, handler: (payload: unknown) => void) => void;
 }
 
 interface WonderSignOptions {
@@ -60,6 +83,7 @@ interface MockWallet {
   accounts: string[];
   address: string;
   publicKey: string;
+  addressType: "p2pkh" | "p2sh" | "p2wpkh" | "p2tr";
   btcBalance: {
     confirmed: number;
     unconfirmed: number;
@@ -67,6 +91,7 @@ interface MockWallet {
   };
   network: "mainnet" | "testnet";
   provider: string;
+  stampBalance: unknown[];
 }
 
 interface SignPSBTResult {
@@ -92,6 +117,66 @@ function mockCheckWonder(
   return !!(wallets?.wonderWallet);
 }
 
+/** Mirror of toAccounts() from wonder.ts. */
+function toAccounts(result: unknown): string[] {
+  const list = Array.isArray(result)
+    ? result
+    : (result as { accounts?: unknown } | null)?.accounts;
+  return Array.isArray(list)
+    ? list.filter((account): account is string => typeof account === "string")
+    : [];
+}
+
+/** Mirror of toTxid() from wonder.ts. */
+function toTxid(result: unknown): string {
+  if (typeof result === "string") return result;
+  const txid = (result as { txid?: unknown } | null)?.txid;
+  return typeof txid === "string" ? txid : "";
+}
+
+/** Mirror of toPsbtHex() from wonder.ts. */
+function toPsbtHex(psbt: string): string {
+  return /^[0-9a-fA-F]+$/.test(psbt) ? psbt : base64ToHex(psbt);
+}
+
+/** Mirror of addressTypeFor() from wonder.ts. */
+function addressTypeFor(address: string): MockWallet["addressType"] {
+  if (address.startsWith("bc1p")) return "p2tr";
+  if (address.startsWith("bc1")) return "p2wpkh";
+  if (address.startsWith("3")) return "p2sh";
+  return "p2pkh";
+}
+
+type ConnectOutcome =
+  | { status: "not-installed" }
+  | { status: "no-accounts" }
+  | { status: "connected"; accounts: string[] }
+  | { status: "error"; message: string };
+
+/**
+ * Mirror of connectWonder() from wonder.ts, reduced to the outcome so tests
+ * can assert without a live toast queue or walletContext.
+ */
+async function mockConnectWonder(
+  provider: MockWonderProvider | undefined,
+): Promise<ConnectOutcome> {
+  if (!provider) {
+    return { status: "not-installed" };
+  }
+  try {
+    const accounts = toAccounts(await provider.requestAccounts());
+    if (accounts.length === 0) {
+      return { status: "no-accounts" };
+    }
+    return { status: "connected", accounts };
+  } catch (error: unknown) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 type AccountsChangedOutcome =
   | { action: "disconnect" }
   | { action: "unchanged" }
@@ -103,11 +188,12 @@ type AccountsChangedOutcome =
  * walletContext.
  */
 async function mockHandleAccountsChanged(
-  accounts: string[] | null | undefined,
+  rawAccounts: unknown,
   provider: MockWonderProvider | undefined,
   currentAddress = "",
 ): Promise<AccountsChangedOutcome> {
-  if (!accounts || accounts.length === 0) {
+  const accounts = toAccounts(rawAccounts);
+  if (accounts.length === 0) {
     return { action: "disconnect" };
   }
   if (currentAddress === accounts[0]) {
@@ -117,7 +203,9 @@ async function mockHandleAccountsChanged(
   const wallet = {} as MockWallet;
   wallet.accounts = accounts;
   wallet.address = accounts[0];
-  wallet.publicKey = await wonder.getPublicKey();
+  const publicKey = await wonder.getPublicKey();
+  wallet.publicKey = typeof publicKey === "string" ? publicKey : "";
+  wallet.addressType = addressTypeFor(accounts[0]);
   const balance = await wonder.getBalances();
   const confirmed = balance?.confirmed ?? 0;
   const unconfirmed = balance?.unconfirmed ?? 0;
@@ -128,6 +216,7 @@ async function mockHandleAccountsChanged(
   };
   wallet.network = "mainnet";
   wallet.provider = "wonder";
+  wallet.stampBalance = [];
   return { action: "update", wallet };
 }
 
@@ -172,7 +261,10 @@ async function mockSignPSBT(
 
     if (autoBroadcast && result.txhex) {
       try {
-        const txid = await wonder.broadcastTransaction(result.txhex);
+        const txid = toTxid(await wonder.broadcastTransaction(result.txhex));
+        if (!txid) {
+          throw new Error("Wonder Wallet did not return a txid");
+        }
         return { signed: true, txid };
       } catch (_broadcastError) {
         return {
@@ -184,7 +276,7 @@ async function mockSignPSBT(
     }
 
     if (result.psbt) {
-      return { signed: true, psbt: result.psbt };
+      return { signed: true, psbt: toPsbtHex(result.psbt) };
     }
     if (result.txhex) {
       return { signed: true, psbt: result.txhex };
@@ -194,6 +286,35 @@ async function mockSignPSBT(
     const message = error instanceof Error ? error.message : String(error);
     return { signed: false, error: message };
   }
+}
+
+/** Mirror of broadcastRawTX() from wonder.ts. */
+async function mockBroadcastRawTX(
+  rawTx: string,
+  provider: MockWonderProvider | undefined,
+): Promise<string> {
+  if (!provider) {
+    throw new Error("Wonder Wallet not connected");
+  }
+  const txid = toTxid(await provider.broadcastTransaction(rawTx));
+  if (!txid) {
+    throw new Error("Wonder Wallet did not return a txid");
+  }
+  return txid;
+}
+
+/** Mirror of broadcastPSBT() from wonder.ts. */
+async function mockBroadcastPSBT(
+  psbtHex: string,
+  provider: MockWonderProvider | undefined,
+): Promise<string> {
+  if (psbtHex.toLowerCase().startsWith("70736274ff")) {
+    throw new Error(
+      "Wonder Wallet cannot broadcast an unfinalized PSBT. " +
+        "Re-sign the transaction to broadcast it.",
+    );
+  }
+  return await mockBroadcastRawTX(psbtHex, provider);
 }
 
 /**
@@ -217,17 +338,19 @@ async function mockSignMessage(
 const PSBT_HEX = "70736274ff01000a0200000000000000000000";
 const ADDRESS = "bc1qwonderpayment123abc";
 const PUBKEY = "02wonderpubkey1234567890abcdef";
+const PROOF = { message: "stampchain.io wants you to connect", signature: "s" };
 
 function buildProvider(
   overrides: Partial<MockWonderProvider> = {},
 ): MockWonderProvider {
   return {
-    requestAccounts: () => Promise.resolve([ADDRESS]),
+    requestAccounts: () =>
+      Promise.resolve({ accounts: [ADDRESS], proof: PROOF }),
     getPublicKey: () => Promise.resolve(PUBKEY),
     getBalances: () =>
       Promise.resolve({ confirmed: 100000, unconfirmed: 0, total: 100000 }),
     signPsbt: () => Promise.resolve({ txhex: "aabbcc", txid: "txid123" }),
-    broadcastTransaction: () => Promise.resolve("broadcasttxid"),
+    broadcastTransaction: () => Promise.resolve({ txid: "broadcasttxid" }),
     signMessage: () => Promise.resolve("signature123"),
     on: () => {},
     ...overrides,
@@ -257,7 +380,101 @@ Deno.test(
 );
 
 // ============================================================================
-// Section 2: handleAccountsChanged() tests
+// Section 2: toAccounts() normalization tests
+// ============================================================================
+
+Deno.test(
+  "toAccounts: unwraps the { accounts, proof } first-connect response",
+  () => {
+    assertEquals(
+      toAccounts({ accounts: [ADDRESS, "bc1qsecond456"], proof: PROOF }),
+      [ADDRESS, "bc1qsecond456"],
+    );
+  },
+);
+
+Deno.test(
+  "toAccounts: passes through the bare array repeat-connect response",
+  () => {
+    assertEquals(toAccounts([ADDRESS]), [ADDRESS]);
+  },
+);
+
+Deno.test("toAccounts: returns empty for null, undefined and {}", () => {
+  assertEquals(toAccounts(null), []);
+  assertEquals(toAccounts(undefined), []);
+  assertEquals(toAccounts({}), []);
+});
+
+Deno.test("toAccounts: returns empty for an empty accounts array", () => {
+  assertEquals(toAccounts({ accounts: [] }), []);
+});
+
+Deno.test("toAccounts: drops non-string entries", () => {
+  assertEquals(toAccounts([ADDRESS, null, 42, undefined]), [ADDRESS]);
+});
+
+// ============================================================================
+// Section 3: connectWonder() tests
+// ============================================================================
+
+Deno.test(
+  "connectWonder: reports not-installed when the provider is missing",
+  async () => {
+    const outcome = await mockConnectWonder(undefined);
+    assertEquals(outcome.status, "not-installed");
+  },
+);
+
+Deno.test(
+  "connectWonder: connects from the { accounts, proof } response",
+  async () => {
+    const outcome = await mockConnectWonder(buildProvider());
+    assertEquals(outcome.status, "connected");
+    if (outcome.status !== "connected") return;
+    assertEquals(outcome.accounts, [ADDRESS]);
+  },
+);
+
+Deno.test(
+  "connectWonder: connects from the bare array response",
+  async () => {
+    const provider = buildProvider({
+      requestAccounts: () => Promise.resolve([ADDRESS]),
+    });
+    const outcome = await mockConnectWonder(provider);
+    assertEquals(outcome.status, "connected");
+    if (outcome.status !== "connected") return;
+    assertEquals(outcome.accounts, [ADDRESS]);
+  },
+);
+
+Deno.test(
+  "connectWonder: reports no-accounts instead of connecting with no address",
+  async () => {
+    const provider = buildProvider({
+      requestAccounts: () => Promise.resolve({ accounts: [], proof: PROOF }),
+    });
+    const outcome = await mockConnectWonder(provider);
+    assertEquals(outcome.status, "no-accounts");
+  },
+);
+
+Deno.test(
+  "connectWonder: surfaces a rejected approval as an error",
+  async () => {
+    const provider = buildProvider({
+      requestAccounts: () => Promise.reject(new Error("user_rejected")),
+    });
+    const outcome = await mockConnectWonder(provider);
+    assertEquals(outcome.status, "error");
+    if (outcome.status !== "error") return;
+    assertEquals(outcome.message, "user_rejected");
+  },
+);
+
+// ============================================================================
+// Section 4: handleAccountsChanged() tests
 // ============================================================================
 
 Deno.test(
@@ -299,6 +516,53 @@ Deno.test(
     assertEquals(outcome.wallet.publicKey, PUBKEY);
     assertEquals(outcome.wallet.provider, "wonder");
     assertEquals(outcome.wallet.network, "mainnet");
+    assertEquals(outcome.wallet.stampBalance, []);
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: builds wallet from the connect response object",
+  async () => {
+    const outcome = await mockHandleAccountsChanged(
+      { accounts: [ADDRESS], proof: PROOF },
+      buildProvider(),
+    );
+    assertEquals(outcome.action, "update");
+    if (outcome.action !== "update") return;
+    assertEquals(outcome.wallet.address, ADDRESS);
+    assertEquals(outcome.wallet.accounts, [ADDRESS]);
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: falls back to an empty publicKey when unavailable",
+  async () => {
+    const provider = buildProvider({
+      getPublicKey: () => Promise.resolve(null),
+    });
+    const outcome = await mockHandleAccountsChanged([ADDRESS], provider);
+    if (outcome.action !== "update") throw new Error("expected update");
+    assertEquals(outcome.wallet.publicKey, "");
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: derives addressType from the address prefix",
+  async () => {
+    const cases: [string, MockWallet["addressType"]][] = [
+      ["bc1qwonderpayment123abc", "p2wpkh"],
+      ["bc1ptaprootaddress123abc", "p2tr"],
+      ["3NestedSegwitAddress123", "p2sh"],
+      ["1LegacyAddress123abcdef", "p2pkh"],
+    ];
+    for (const [address, expected] of cases) {
+      const outcome = await mockHandleAccountsChanged(
+        [address],
+        buildProvider(),
+      );
+      if (outcome.action !== "update") throw new Error("expected update");
+      assertEquals(outcome.wallet.addressType, expected);
+    }
   },
 );
 
@@ -357,7 +621,7 @@ Deno.test(
 );
 
 // ============================================================================
-// Section 3: signPSBT() tests
+// Section 5: signPSBT() tests
 // ============================================================================
 
 Deno.test(
@@ -377,7 +641,28 @@ Deno.test(
 );
 
 Deno.test(
-  "signPSBT: auto-broadcasts finalized txhex and returns txid",
+  "signPSBT: unwraps the { txid } broadcast response into a txid string",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({ txhex: "deadbeef", txid: "signed" }),
+      broadcastTransaction: () => Promise.resolve({ txid: "finaltxid" }),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      true,
+      provider,
+    );
+    assertEquals(result.signed, true);
+    assertEquals(result.txid, "finaltxid");
+    assertEquals(typeof result.txid, "string");
+  },
+);
+
+Deno.test(
+  "signPSBT: accepts a bare txid string broadcast response",
   async () => {
     const provider = buildProvider({
       signPsbt: () => Promise.resolve({ txhex: "deadbeef" }),
@@ -393,6 +678,28 @@ Deno.test(
     );
     assertEquals(result.signed, true);
     assertEquals(result.txid, "finaltxid");
+  },
+);
+
+Deno.test(
+  "signPSBT: falls back to signed txhex when broadcast returns no txid",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({ txhex: "deadbeef" }),
+      broadcastTransaction: () => Promise.resolve({}),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      true,
+      provider,
+    );
+    assertEquals(result.signed, true);
+    assertEquals(result.txid, undefined);
+    assertEquals(result.psbt, "deadbeef");
+    assertEquals(result.error, "Transaction signed but broadcast failed");
   },
 );
 
@@ -418,10 +725,11 @@ Deno.test(
 );
 
 Deno.test(
-  "signPSBT: returns signed psbt when not auto-broadcasting",
+  "signPSBT: converts a base64 signed PSBT to hex",
   async () => {
+    const signedHex = "70736274ffdeadbeef";
     const provider = buildProvider({
-      signPsbt: () => Promise.resolve({ psbt: "signedpsbthex" }),
+      signPsbt: () => Promise.resolve({ psbt: hexToBase64(signedHex) }),
     });
     const result = await mockSignPSBT(
       PSBT_HEX,
@@ -432,7 +740,26 @@ Deno.test(
       provider,
     );
     assertEquals(result.signed, true);
-    assertEquals(result.psbt, "signedpsbthex");
+    assertEquals(result.psbt, signedHex);
+  },
+);
+
+Deno.test(
+  "signPSBT: leaves an already-hex signed PSBT untouched",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({ psbt: "70736274ffaabbcc" }),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      false,
+      provider,
+    );
+    assertEquals(result.signed, true);
+    assertEquals(result.psbt, "70736274ffaabbcc");
     assertEquals(result.txid, undefined);
   },
 );
@@ -580,7 +907,73 @@ Deno.test(
 );
 
 // ============================================================================
-// Section 4: signMessage() tests
+// Section 6: broadcastRawTX() / broadcastPSBT() tests
+// ============================================================================
+
+Deno.test(
+  "broadcastRawTX: unwraps the { txid } response",
+  async () => {
+    const txid = await mockBroadcastRawTX("aabbcc", buildProvider());
+    assertEquals(txid, "broadcasttxid");
+  },
+);
+
+Deno.test(
+  "broadcastRawTX: accepts a bare txid string response",
+  async () => {
+    const provider = buildProvider({
+      broadcastTransaction: () => Promise.resolve("plaintxid"),
+    });
+    assertEquals(await mockBroadcastRawTX("aabbcc", provider), "plaintxid");
+  },
+);
+
+Deno.test(
+  "broadcastRawTX: throws when the provider is missing",
+  async () => {
+    await assertRejects(
+      () => mockBroadcastRawTX("aabbcc", undefined),
+      Error,
+      "Wonder Wallet not connected",
+    );
+  },
+);
+
+Deno.test(
+  "broadcastRawTX: throws when the response carries no txid",
+  async () => {
+    const provider = buildProvider({
+      broadcastTransaction: () => Promise.resolve({}),
+    });
+    await assertRejects(
+      () => mockBroadcastRawTX("aabbcc", provider),
+      Error,
+      "did not return a txid",
+    );
+  },
+);
+
+Deno.test(
+  "broadcastPSBT: forwards a finalized raw transaction",
+  async () => {
+    const txid = await mockBroadcastPSBT("aabbcc", buildProvider());
+    assertEquals(txid, "broadcasttxid");
+  },
+);
+
+Deno.test(
+  "broadcastPSBT: rejects an unfinalized PSBT",
+  async () => {
+    await assertRejects(
+      () => mockBroadcastPSBT(PSBT_HEX, buildProvider()),
+      Error,
+      "cannot broadcast an unfinalized PSBT",
+    );
+  },
+);
+
+// ============================================================================
+// Section 7: signMessage() tests
 // ============================================================================
 
 Deno.test(
@@ -621,19 +1014,25 @@ Deno.test(
 );
 
 // ============================================================================
-// Section 5: wonderProvider structure tests
+// Section 8: wonderProvider structure tests
 // ============================================================================
 
 Deno.test(
-  "wonderProvider: exposes connectWonder, signPSBT and signMessage",
+  "wonderProvider: exposes the full WalletProvider surface",
   () => {
     const wonderProvider = {
+      checkWonder: () => {},
       connectWonder: () => {},
       signPSBT: () => {},
       signMessage: () => {},
+      broadcastRawTX: () => {},
+      broadcastPSBT: () => {},
     };
+    assertEquals(typeof wonderProvider.checkWonder, "function");
     assertEquals(typeof wonderProvider.connectWonder, "function");
     assertEquals(typeof wonderProvider.signPSBT, "function");
     assertEquals(typeof wonderProvider.signMessage, "function");
+    assertEquals(typeof wonderProvider.broadcastRawTX, "function");
+    assertEquals(typeof wonderProvider.broadcastPSBT, "function");
   },
 );

--- a/tests/unit/wallet/wonder.test.ts
+++ b/tests/unit/wallet/wonder.test.ts
@@ -1,0 +1,639 @@
+/**
+ * Comprehensive unit tests for client/wallet/wonder.ts
+ *
+ * Tests cover:
+ *   - checkWonder() provider detection
+ *   - handleAccountsChanged() account/balance mapping and disconnect handling
+ *   - signPSBT() PSBT signing with the Wonder (UniSat-style) API
+ *   - signMessage() message signing
+ *   - wonderProvider object structure and interface compliance
+ *
+ * Approach: All tests use local mock implementations to avoid importing
+ * browser-dependent modules (window, Preact signals, walletContext) in a
+ * Deno server-side test environment. Mocks mirror the exact logic in wonder.ts
+ * to validate behavior independently — the same approach used by
+ * tests/unit/wallet/xverse.test.ts.
+ */
+
+import { assertEquals, assertRejects } from "@std/assert";
+
+// ============================================================================
+// Type definitions mirroring the Wonder provider + wallet types
+// ============================================================================
+
+interface MockBalance {
+  confirmed?: number;
+  unconfirmed?: number;
+  total?: number;
+}
+
+interface MockWonderProvider {
+  requestAccounts: () => Promise<string[]>;
+  getPublicKey: () => Promise<string>;
+  getBalances: () => Promise<MockBalance | undefined>;
+  signPsbt: (
+    psbtHex: string,
+    options: WonderSignOptions,
+  ) => Promise<WonderSignResult | undefined>;
+  broadcastTransaction: (txhex: string) => Promise<string>;
+  signMessage: (message: string) => Promise<string>;
+  on?: (event: string, handler: (accounts: string[]) => void) => void;
+}
+
+interface WonderSignOptions {
+  autoFinalized: boolean;
+  enableRBF: boolean;
+  toSignInputs?: {
+    index: number;
+    address: string;
+    sighashTypes?: number[] | undefined;
+  }[];
+}
+
+interface WonderSignResult {
+  txhex?: string;
+  txid?: string;
+  psbt?: string;
+}
+
+interface MockWallet {
+  accounts: string[];
+  address: string;
+  publicKey: string;
+  btcBalance: {
+    confirmed: number;
+    unconfirmed: number;
+    total: number;
+  };
+  network: "mainnet" | "testnet";
+  provider: string;
+}
+
+interface SignPSBTResult {
+  signed: boolean;
+  psbt?: string;
+  txid?: string;
+  error?: string;
+  cancelled?: boolean;
+}
+
+// ============================================================================
+// Local re-implementations mirroring wonder.ts logic for isolated testing
+// ============================================================================
+
+/**
+ * Mirror of checkWonder() detection logic from wonder.ts.
+ * checkWalletAvailability("wonder") resolves to whether wonderWallet is on
+ * the global wallets object.
+ */
+function mockCheckWonder(
+  wallets: { wonderWallet?: MockWonderProvider } | undefined,
+): boolean {
+  return !!(wallets?.wonderWallet);
+}
+
+type AccountsChangedOutcome =
+  | { action: "disconnect" }
+  | { action: "unchanged" }
+  | { action: "update"; wallet: MockWallet };
+
+/**
+ * Mirror of handleAccountsChanged() from wonder.ts.
+ * Returns the resulting action so tests can assert on it without a live
+ * walletContext.
+ */
+async function mockHandleAccountsChanged(
+  accounts: string[] | null | undefined,
+  provider: MockWonderProvider | undefined,
+  currentAddress = "",
+): Promise<AccountsChangedOutcome> {
+  if (!accounts || accounts.length === 0) {
+    return { action: "disconnect" };
+  }
+  if (currentAddress === accounts[0]) {
+    return { action: "unchanged" };
+  }
+  const wonder = provider!;
+  const wallet = {} as MockWallet;
+  wallet.accounts = accounts;
+  wallet.address = accounts[0];
+  wallet.publicKey = await wonder.getPublicKey();
+  const balance = await wonder.getBalances();
+  const confirmed = balance?.confirmed ?? 0;
+  const unconfirmed = balance?.unconfirmed ?? 0;
+  wallet.btcBalance = {
+    confirmed,
+    unconfirmed,
+    total: balance?.total ?? confirmed + unconfirmed,
+  };
+  wallet.network = "mainnet";
+  wallet.provider = "wonder";
+  return { action: "update", wallet };
+}
+
+/**
+ * Mirror of signPSBT() from wonder.ts.
+ * Wonder is UniSat-style: with autoFinalized it returns a finalized
+ * { txhex, txid }; without it, a signed { psbt }.
+ */
+async function mockSignPSBT(
+  psbtHex: string,
+  inputsToSign: { index: number }[],
+  enableRBF = true,
+  sighashTypes: number[] | undefined = undefined,
+  autoBroadcast = true,
+  provider: MockWonderProvider | undefined = undefined,
+  walletAddress = "bc1qtest123",
+): Promise<SignPSBTResult> {
+  try {
+    const wonder = provider;
+    if (!wonder) {
+      return { signed: false, error: "Wonder Wallet not connected" };
+    }
+
+    const options: WonderSignOptions = {
+      autoFinalized: autoBroadcast,
+      enableRBF,
+    };
+    if (inputsToSign?.length > 0) {
+      options.toSignInputs = inputsToSign.map((input) => ({
+        index: input.index,
+        address: walletAddress,
+        sighashTypes,
+      }));
+    }
+
+    const rawResult = await wonder.signPsbt(psbtHex, options);
+    const result = rawResult as WonderSignResult | undefined;
+
+    if (!result) {
+      return { signed: false, error: "No result from Wonder Wallet" };
+    }
+
+    if (autoBroadcast && result.txhex) {
+      try {
+        const txid = await wonder.broadcastTransaction(result.txhex);
+        return { signed: true, txid };
+      } catch (_broadcastError) {
+        return {
+          signed: true,
+          psbt: result.txhex,
+          error: "Transaction signed but broadcast failed",
+        };
+      }
+    }
+
+    if (result.psbt) {
+      return { signed: true, psbt: result.psbt };
+    }
+    if (result.txhex) {
+      return { signed: true, psbt: result.txhex };
+    }
+    return { signed: false, error: "No signed result from Wonder Wallet" };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { signed: false, error: message };
+  }
+}
+
+/**
+ * Mirror of signMessage() from wonder.ts.
+ */
+async function mockSignMessage(
+  message: string,
+  provider: MockWonderProvider | undefined,
+): Promise<string> {
+  const wonder = provider;
+  if (!wonder) {
+    throw new Error("Wonder Wallet not connected");
+  }
+  return await wonder.signMessage(message);
+}
+
+// ============================================================================
+// Test helpers / constants
+// ============================================================================
+
+const PSBT_HEX = "70736274ff01000a0200000000000000000000";
+const ADDRESS = "bc1qwonderpayment123abc";
+const PUBKEY = "02wonderpubkey1234567890abcdef";
+
+function buildProvider(
+  overrides: Partial<MockWonderProvider> = {},
+): MockWonderProvider {
+  return {
+    requestAccounts: () => Promise.resolve([ADDRESS]),
+    getPublicKey: () => Promise.resolve(PUBKEY),
+    getBalances: () =>
+      Promise.resolve({ confirmed: 100000, unconfirmed: 0, total: 100000 }),
+    signPsbt: () => Promise.resolve({ txhex: "aabbcc", txid: "txid123" }),
+    broadcastTransaction: () => Promise.resolve("broadcasttxid"),
+    signMessage: () => Promise.resolve("signature123"),
+    on: () => {},
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Section 1: checkWonder() detection tests
+// ============================================================================
+
+Deno.test("checkWonder: returns false when wallets object is undefined", () => {
+  assertEquals(mockCheckWonder(undefined), false);
+});
+
+Deno.test(
+  "checkWonder: returns false when wonderWallet is absent",
+  () => {
+    assertEquals(mockCheckWonder({}), false);
+  },
+);
+
+Deno.test(
+  "checkWonder: returns true when wonderWallet provider is present",
+  () => {
+    assertEquals(mockCheckWonder({ wonderWallet: buildProvider() }), true);
+  },
+);
+
+// ============================================================================
+// Section 2: handleAccountsChanged() tests
+// ============================================================================
+
+Deno.test(
+  "handleAccountsChanged: disconnects when accounts is null",
+  async () => {
+    const outcome = await mockHandleAccountsChanged(null, buildProvider());
+    assertEquals(outcome.action, "disconnect");
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: disconnects when accounts is empty",
+  async () => {
+    const outcome = await mockHandleAccountsChanged([], buildProvider());
+    assertEquals(outcome.action, "disconnect");
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: no-op when first account equals current address",
+  async () => {
+    const outcome = await mockHandleAccountsChanged(
+      [ADDRESS],
+      buildProvider(),
+      ADDRESS,
+    );
+    assertEquals(outcome.action, "unchanged");
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: builds wallet from first account",
+  async () => {
+    const outcome = await mockHandleAccountsChanged([ADDRESS], buildProvider());
+    assertEquals(outcome.action, "update");
+    if (outcome.action !== "update") return;
+    assertEquals(outcome.wallet.address, ADDRESS);
+    assertEquals(outcome.wallet.accounts, [ADDRESS]);
+    assertEquals(outcome.wallet.publicKey, PUBKEY);
+    assertEquals(outcome.wallet.provider, "wonder");
+    assertEquals(outcome.wallet.network, "mainnet");
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: maps confirmed/unconfirmed/total balance",
+  async () => {
+    const provider = buildProvider({
+      getBalances: () =>
+        Promise.resolve({ confirmed: 5000, unconfirmed: 250, total: 5250 }),
+    });
+    const outcome = await mockHandleAccountsChanged([ADDRESS], provider);
+    if (outcome.action !== "update") throw new Error("expected update");
+    assertEquals(outcome.wallet.btcBalance.confirmed, 5000);
+    assertEquals(outcome.wallet.btcBalance.unconfirmed, 250);
+    assertEquals(outcome.wallet.btcBalance.total, 5250);
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: derives total when provider omits it",
+  async () => {
+    const provider = buildProvider({
+      getBalances: () => Promise.resolve({ confirmed: 700, unconfirmed: 300 }),
+    });
+    const outcome = await mockHandleAccountsChanged([ADDRESS], provider);
+    if (outcome.action !== "update") throw new Error("expected update");
+    assertEquals(outcome.wallet.btcBalance.total, 1000);
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: defaults balances to zero when missing",
+  async () => {
+    const provider = buildProvider({
+      getBalances: () => Promise.resolve(undefined),
+    });
+    const outcome = await mockHandleAccountsChanged([ADDRESS], provider);
+    if (outcome.action !== "update") throw new Error("expected update");
+    assertEquals(outcome.wallet.btcBalance.confirmed, 0);
+    assertEquals(outcome.wallet.btcBalance.unconfirmed, 0);
+    assertEquals(outcome.wallet.btcBalance.total, 0);
+  },
+);
+
+Deno.test(
+  "handleAccountsChanged: selects the first of multiple accounts",
+  async () => {
+    const outcome = await mockHandleAccountsChanged(
+      [ADDRESS, "bc1qsecond456"],
+      buildProvider(),
+    );
+    if (outcome.action !== "update") throw new Error("expected update");
+    assertEquals(outcome.wallet.address, ADDRESS);
+    assertEquals(outcome.wallet.accounts.length, 2);
+  },
+);
+
+// ============================================================================
+// Section 3: signPSBT() tests
+// ============================================================================
+
+Deno.test(
+  "signPSBT: returns error when provider not connected",
+  async () => {
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      true,
+      undefined,
+    );
+    assertEquals(result.signed, false);
+    assertEquals(result.error, "Wonder Wallet not connected");
+  },
+);
+
+Deno.test(
+  "signPSBT: auto-broadcasts finalized txhex and returns txid",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({ txhex: "deadbeef" }),
+      broadcastTransaction: () => Promise.resolve("finaltxid"),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      true,
+      provider,
+    );
+    assertEquals(result.signed, true);
+    assertEquals(result.txid, "finaltxid");
+  },
+);
+
+Deno.test(
+  "signPSBT: falls back to signed txhex when broadcast fails",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({ txhex: "deadbeef" }),
+      broadcastTransaction: () => Promise.reject(new Error("network down")),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      true,
+      provider,
+    );
+    assertEquals(result.signed, true);
+    assertEquals(result.psbt, "deadbeef");
+    assertEquals(result.error, "Transaction signed but broadcast failed");
+  },
+);
+
+Deno.test(
+  "signPSBT: returns signed psbt when not auto-broadcasting",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({ psbt: "signedpsbthex" }),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      false,
+      provider,
+    );
+    assertEquals(result.signed, true);
+    assertEquals(result.psbt, "signedpsbthex");
+    assertEquals(result.txid, undefined);
+  },
+);
+
+Deno.test(
+  "signPSBT: returns txhex as psbt when no-broadcast wallet returns txhex only",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({ txhex: "rawtxhex" }),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      false,
+      provider,
+    );
+    assertEquals(result.signed, true);
+    assertEquals(result.psbt, "rawtxhex");
+  },
+);
+
+Deno.test(
+  "signPSBT: errors when provider returns no result",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve(undefined),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      true,
+      provider,
+    );
+    assertEquals(result.signed, false);
+    assertEquals(result.error, "No result from Wonder Wallet");
+  },
+);
+
+Deno.test(
+  "signPSBT: errors when result has neither txhex nor psbt",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.resolve({}),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      false,
+      provider,
+    );
+    assertEquals(result.signed, false);
+    assertEquals(result.error, "No signed result from Wonder Wallet");
+  },
+);
+
+Deno.test(
+  "signPSBT: maps toSignInputs with address and sighashTypes",
+  async () => {
+    let captured: WonderSignOptions | undefined;
+    const provider = buildProvider({
+      signPsbt: (_hex, options) => {
+        captured = options;
+        return Promise.resolve({ psbt: "ok" });
+      },
+    });
+    await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }, { index: 2 }],
+      true,
+      [1],
+      false,
+      provider,
+      "bc1qmine",
+    );
+    assertEquals(captured?.autoFinalized, false);
+    assertEquals(captured?.enableRBF, true);
+    assertEquals(captured?.toSignInputs?.length, 2);
+    assertEquals(captured?.toSignInputs?.[0].index, 0);
+    assertEquals(captured?.toSignInputs?.[0].address, "bc1qmine");
+    assertEquals(captured?.toSignInputs?.[0].sighashTypes, [1]);
+    assertEquals(captured?.toSignInputs?.[1].index, 2);
+  },
+);
+
+Deno.test(
+  "signPSBT: omits toSignInputs when no inputs provided",
+  async () => {
+    let captured: WonderSignOptions | undefined;
+    const provider = buildProvider({
+      signPsbt: (_hex, options) => {
+        captured = options;
+        return Promise.resolve({ psbt: "ok" });
+      },
+    });
+    await mockSignPSBT(PSBT_HEX, [], true, undefined, false, provider);
+    assertEquals(captured?.toSignInputs, undefined);
+  },
+);
+
+Deno.test(
+  "signPSBT: passes enableRBF flag through to options",
+  async () => {
+    let captured: WonderSignOptions | undefined;
+    const provider = buildProvider({
+      signPsbt: (_hex, options) => {
+        captured = options;
+        return Promise.resolve({ psbt: "ok" });
+      },
+    });
+    await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      false,
+      undefined,
+      false,
+      provider,
+    );
+    assertEquals(captured?.enableRBF, false);
+  },
+);
+
+Deno.test(
+  "signPSBT: returns error message when signPsbt throws",
+  async () => {
+    const provider = buildProvider({
+      signPsbt: () => Promise.reject(new Error("user rejected")),
+    });
+    const result = await mockSignPSBT(
+      PSBT_HEX,
+      [{ index: 0 }],
+      true,
+      undefined,
+      true,
+      provider,
+    );
+    assertEquals(result.signed, false);
+    assertEquals(result.error, "user rejected");
+  },
+);
+
+// ============================================================================
+// Section 4: signMessage() tests
+// ============================================================================
+
+Deno.test(
+  "signMessage: throws when provider not connected",
+  async () => {
+    await assertRejects(
+      () => mockSignMessage("hello", undefined),
+      Error,
+      "Wonder Wallet not connected",
+    );
+  },
+);
+
+Deno.test(
+  "signMessage: returns signature from provider",
+  async () => {
+    const provider = buildProvider({
+      signMessage: () => Promise.resolve("0xsignedmessage"),
+    });
+    const sig = await mockSignMessage("hello world", provider);
+    assertEquals(sig, "0xsignedmessage");
+  },
+);
+
+Deno.test(
+  "signMessage: forwards the exact message to the provider",
+  async () => {
+    let captured = "";
+    const provider = buildProvider({
+      signMessage: (message) => {
+        captured = message;
+        return Promise.resolve("sig");
+      },
+    });
+    await mockSignMessage("prove ownership", provider);
+    assertEquals(captured, "prove ownership");
+  },
+);
+
+// ============================================================================
+// Section 5: wonderProvider structure tests
+// ============================================================================
+
+Deno.test(
+  "wonderProvider: exposes connectWonder, signPSBT and signMessage",
+  () => {
+    const wonderProvider = {
+      connectWonder: () => {},
+      signPSBT: () => {},
+      signMessage: () => {},
+    };
+    assertEquals(typeof wonderProvider.connectWonder, "function");
+    assertEquals(typeof wonderProvider.signPSBT, "function");
+    assertEquals(typeof wonderProvider.signMessage, "function");
+  },
+);


### PR DESCRIPTION
Closes #1225.

## Summary

Adds **Wonder Wallet** ([wonder-wallet.com](https://wonder-wallet.com)) as a supported connect option, mirroring the existing per‑wallet adapters. Wonder is a self‑custodial Bitcoin wallet built for the Stamps / SRC‑20 / Counterparty community, and it injects a **UniSat‑style provider (`window.wonderWallet`)** on every site — so this is a self‑contained adapter + registration, with no protocol changes.

Following the 👍 on #1225. I kept the defaults proposed there (global `window.wonderWallet`, connect key `"wonder"`, display name "Wonder") — happy to adjust naming or the icon to taste.

## Changes

- **`client/wallet/wonder.ts`** (new) — adapter mirroring `unisat.ts`: `connectWonder`, `signPSBT`, `signMessage`. Wonder's `signPsbt(hex, { autoFinalized })` returns the finalized `{ txhex, txid }` (broadcast via `broadcastTransaction`) or a signed `{ psbt }` — handled the same way `leather.ts` handles `{ txid }` vs `{ hex }`.
- **`client/wallet/wallet.ts`** — register `wonderWallet` detection (`WalletProviders`, `getGlobalWallets`, `checkWalletAvailability("wonder")`).
- **`client/wallet/walletHelper.ts`** — dispatch `"wonder" → wonderProvider`.
- **`islands/layout/WalletProvider.tsx`** — connect‑list connector.
- **`lib/constants/walletProviders.ts`** — `WalletProviderKey`, `WALLET_PROVIDERS` config, and `DEFAULT_WALLET_CONNECTORS`.
- **`static/img/wallet/wonder/logo_wonder.svg`** — brand icon.

## Provider surface used (`window.wonderWallet`)

`requestAccounts()` → `string[]`, `getPublicKey()` → `string`, `getBalances()` → `{ confirmed, unconfirmed, total }`, `signPsbt(hex, { autoFinalized, toSignInputs })` → `{ txhex, txid }` | `{ psbt }`, `broadcastTransaction(hex)` → `txid`, `signMessage(msg)` → signature, `on(event, handler)`. It signs only the inputs it owns.

## Validation

- Ran locally against the changed files: **`deno fmt --check`**, **`deno lint`**, and **`deno check`** — all clean, no `any` (adapter respects `exactOptionalPropertyTypes`). A full‑repo `deno check` surfaces some pre‑existing `Timeout`/`number` errors under `server/` that are unrelated to this change.
- I have **not** wired a functional end‑to‑end connect in CI here — I'd welcome a functional review, and I'm happy to record a short demo of connect + SRC‑20/Stamp signing on testnet4.
- `installUrl` currently points at wonder-wallet.com; glad to swap in the Chrome Web Store listing URL if you'd prefer a direct install link.

Thanks again for the quick 👍 — happy to iterate on anything.
