### PR TITLE
ci(dependabot): drop unsupported semver cooldown keys from github-actions entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # github-actions has no semver metadata, so only default-days is valid here;
+    # the per-semver cooldown keys are rejected by Dependabot's config validator.
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary
Dependabot's config validator rejects `cooldown.semver-major-days` / `semver-minor-days` / `semver-patch-days` for the `github-actions` ecosystem (surfaced as the failing `.github/dependabot.yml` check on #1075 after its rebase). An invalid config disables the whole file, so neither the GitHub Actions group nor the npm group has opened update PRs since the cooldown block landed in 6b17fddc9 (2026-05-15).

This keeps `default-days: 7` for github-actions and leaves the npm entry's per-semver cooldown untouched.

## Validation
- The Dependabot `.github/dependabot.yml` check-run on this PR should now pass (it fires because the branch delta touches the file).

Tracked as `1225@stampchain-io`.