### PR TITLE
fix(responses): migrate remaining manual Response() sites to response helpers

### DIFF
--- a/lib/utils/api/responses/webResponseUtil.ts
+++ b/lib/utils/api/responses/webResponseUtil.ts
@@ -287,16 +287,52 @@ export class WebResponseUtil {
     });
   }
 
+  /**
+   * Re-emit an upstream response with a replaced body and optional header
+   * overrides. Headers are merged case-insensitively so an override such as
+   * `Vary` or `Cache-Control` replaces the upstream value regardless of key
+   * casing. Pass `immutableBinary: true` to keep `Vary` limited to
+   * `Accept-Encoding` (plus any caller-supplied values) so Cloudflare can
+   * cache the response at the edge.
+   */
   static modifiedResponse(
     content: string,
     originalResponse: Response,
     options: WebResponseOptions = {},
   ): Response {
+    const merged = new Headers(originalResponse.headers);
+    for (const [key, value] of Object.entries(options.headers || {})) {
+      merged.set(key, value);
+    }
     return new Response(content, {
-      status: originalResponse.status,
+      status: options.status ?? originalResponse.status,
       statusText: originalResponse.statusText,
+      headers: normalizeHeaders(
+        merged,
+        options.immutableBinary ? { immutableBinary: true } : {},
+      ),
+    });
+  }
+
+  /**
+   * XML document response (sitemaps, feeds). Mirrors `htmlResponse` but with
+   * an XML content type. Caller-supplied headers override the defaults, so
+   * pass explicit `Cache-Control` / CDN cache headers when the document must
+   * not inherit the 1-year immutable default from `getSecurityHeaders`.
+   */
+  static xmlResponse(
+    xmlContent: string,
+    options: WebResponseOptions = {},
+  ): Response {
+    return new Response(xmlContent, {
+      status: options.status || 200,
       headers: normalizeHeaders({
-        ...Object.fromEntries(originalResponse.headers.entries()),
+        ...getSecurityHeaders({
+          forceNoCache: options.forceNoCache ?? false,
+          context: "web",
+        }),
+        "Content-Type": "application/xml; charset=utf-8",
+        "X-API-Version": API_RESPONSE_VERSION,
         ...(options.headers || {}),
       }),
     });

--- a/routes/api/_middleware.ts
+++ b/routes/api/_middleware.ts
@@ -178,16 +178,14 @@ export async function handler(
         method: req.method,
         error: error.message,
       });
-      return new Response(
-        JSON.stringify({
+      return ApiResponseUtil.custom(
+        {
           status: "error",
           message: "Request timeout - the operation took too long to complete",
           error: "GATEWAY_TIMEOUT",
-        }),
-        {
-          status: 504,
-          headers: { "Content-Type": "application/json" },
         },
+        504,
+        { forceNoCache: true },
       );
     }
 

--- a/routes/api/v2/keys/index.ts
+++ b/routes/api/v2/keys/index.ts
@@ -74,15 +74,15 @@ export const handler: Handlers = {
         await redis.pexpire(signupKey, 60 * 60 * 1000);
       }
       if (signupCount > 3) {
-        return new Response(
-          JSON.stringify({
+        return ApiResponseUtil.custom(
+          {
             error: "Too many signup attempts. Limit: 3 per hour per IP.",
             retryAfter: 3600,
-          }),
+          },
+          429,
           {
-            status: 429,
+            ...noCache,
             headers: {
-              "Content-Type": "application/json",
               "Retry-After": "3600",
               "Cache-Control": "no-store",
             },
@@ -108,18 +108,13 @@ export const handler: Handlers = {
       if (
         msg.includes("Duplicate entry") || msg.includes("unique constraint")
       ) {
-        return new Response(
-          JSON.stringify({
+        return ApiResponseUtil.custom(
+          {
             error: "An API key already exists for this email address.",
             code: "DUPLICATE_EMAIL",
-          }),
-          {
-            status: 409,
-            headers: {
-              "Content-Type": "application/json",
-              "Cache-Control": "no-store",
-            },
           },
+          409,
+          { ...noCache, headers: { "Cache-Control": "no-store" } },
         );
       }
 

--- a/routes/handlers/sharedContentHandler.ts
+++ b/routes/handlers/sharedContentHandler.ts
@@ -119,17 +119,18 @@ export async function handleContentRequest(
     const contentType = response.headers.get("content-type") || "";
     if (response.ok && contentType.includes("text/html")) {
       const body = await response.text();
-      const headers = new Headers(response.headers);
-      headers.set("Cache-Control", "public, max-age=3600, no-transform");
-      headers.set("CDN-Cache-Control", "public, max-age=86400");
-      // Override Vary to only include CF-supported values.
-      // Default "X-API-Version" in Vary causes CF to skip caching.
-      headers.set("Vary", "Accept-Encoding");
-      headers.set("X-Frame-Options", "SAMEORIGIN");
-      headers.set("X-Content-Type-Options", "nosniff");
-      return new Response(body, {
-        status: response.status,
-        headers,
+      return WebResponseUtil.modifiedResponse(body, response, {
+        headers: {
+          "Cache-Control": "public, max-age=3600, no-transform",
+          "CDN-Cache-Control": "public, max-age=86400",
+          // Override Vary to only include CF-supported values.
+          // Default "X-API-Version" in Vary causes CF to skip caching.
+          "Vary": "Accept-Encoding",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+        },
+        // Keep normalizeHeaders from re-adding X-API-Version/Origin to Vary.
+        immutableBinary: true,
       });
     }
 

--- a/routes/sitemap.xml.ts
+++ b/routes/sitemap.xml.ts
@@ -1,6 +1,12 @@
 import { Handlers } from "$fresh/server.ts";
+import { WebResponseUtil } from "$lib/utils/api/responses/webResponseUtil.ts";
 
 const SITE_URL = "https://stampchain.io";
+
+// Sitemap is regenerated on every request (lastmod = today), so cap all
+// cache layers at one hour instead of the 1-year immutable default.
+const SITEMAP_CACHE_SECONDS = 3600;
+const SITEMAP_CACHE_CONTROL = `public, max-age=${SITEMAP_CACHE_SECONDS}`;
 
 // Static pages with their priorities and change frequencies
 const STATIC_PAGES: Array<{
@@ -58,10 +64,13 @@ ${urls}
 export const handler: Handlers = {
   GET(_req, _ctx) {
     const xml = generateSitemapXml();
-    return new Response(xml, {
+    return WebResponseUtil.xmlResponse(xml, {
       headers: {
-        "Content-Type": "application/xml; charset=utf-8",
-        "Cache-Control": "public, max-age=3600",
+        "Cache-Control": SITEMAP_CACHE_CONTROL,
+        "CDN-Cache-Control": SITEMAP_CACHE_CONTROL,
+        "Cloudflare-CDN-Cache-Control": SITEMAP_CACHE_CONTROL,
+        "Surrogate-Control": `max-age=${SITEMAP_CACHE_SECONDS}`,
+        "Edge-Control": `cache-maxage=${SITEMAP_CACHE_SECONDS}`,
       },
     });
   },

--- a/tests/unit/routeResponseHelpers.test.ts
+++ b/tests/unit/routeResponseHelpers.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Route-level tests for the manual `new Response()` sites migrated to
+ * ApiResponseUtil / WebResponseUtil (issue #1223).
+ *
+ * Each test pins the status, content-type, cache headers and body that the
+ * route emitted BEFORE the migration so the helper-based version is proven
+ * equivalent on the wire.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { afterEach, describe, it } from "jsr:@std/testing@1.0.14/bdd";
+import { restore, stub } from "@std/testing@1.0.14/mock";
+
+import { handler as sitemapHandler } from "../../routes/sitemap.xml.ts";
+import { handleContentRequest } from "../../routes/handlers/sharedContentHandler.ts";
+import { handler as keysHandler } from "../../routes/api/v2/keys/index.ts";
+import { handler as apiMiddleware } from "../../routes/api/_middleware.ts";
+import { StampController } from "$server/controller/stampController.ts";
+import { ApiKeyService } from "$server/services/apiKey/apiKeyService.ts";
+import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
+
+const silence = () => {
+  const noop = () => {};
+  const saved = { error: console.error, warn: console.warn, log: console.log };
+  console.error = noop;
+  console.warn = noop;
+  console.log = noop;
+  return () => {
+    console.error = saved.error;
+    console.warn = saved.warn;
+    console.log = saved.log;
+  };
+};
+
+describe("routes/sitemap.xml.ts", () => {
+  it("returns XML with a 1h public cache on every cache layer", async () => {
+    const req = new Request("https://stampchain.io/sitemap.xml");
+    const res = await sitemapHandler.GET!(req, {} as never);
+
+    assertEquals(res.status, 200);
+    assertEquals(
+      res.headers.get("content-type"),
+      "application/xml; charset=utf-8",
+    );
+    assertEquals(res.headers.get("cache-control"), "public, max-age=3600");
+    assertEquals(res.headers.get("cdn-cache-control"), "public, max-age=3600");
+    assertEquals(
+      res.headers.get("cloudflare-cdn-cache-control"),
+      "public, max-age=3600",
+    );
+    assertEquals(res.headers.get("surrogate-control"), "max-age=3600");
+    assertEquals(res.headers.get("edge-control"), "cache-maxage=3600");
+    assertEquals(res.headers.get("x-api-version") !== null, true);
+
+    const body = await res.text();
+    assertStringIncludes(body, '<?xml version="1.0" encoding="UTF-8"?>');
+    assertStringIncludes(
+      body,
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    assertStringIncludes(body, "<loc>https://stampchain.io/</loc>");
+    assertStringIncludes(body, "<loc>https://stampchain.io/marketplace</loc>");
+  });
+});
+
+describe("routes/handlers/sharedContentHandler.ts", () => {
+  afterEach(() => restore());
+
+  it("re-emits direct 200 HTML with edge-cache headers and CF-safe Vary", async () => {
+    const txHash = "a".repeat(64);
+    const html = "<html><body>stamp</body></html>";
+    stub(
+      StampController,
+      "getStampFile",
+      () =>
+        Promise.resolve(
+          new Response(html, {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "vary": "Accept-Encoding, X-API-Version, Origin",
+              "cache-control": "public, max-age=31536000, immutable",
+              "x-frame-options": "DENY",
+              "x-custom-upstream": "kept",
+            },
+          }),
+        ),
+    );
+
+    const ctx = {
+      url: new URL(`https://stampchain.io/content/${txHash}`),
+      state: { baseUrl: "https://stampchain.io" },
+    } as never;
+    const res = await handleContentRequest(txHash, ctx);
+
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("content-type"), "text/html; charset=utf-8");
+    assertEquals(
+      res.headers.get("cache-control"),
+      "public, max-age=3600, no-transform",
+    );
+    assertEquals(res.headers.get("cdn-cache-control"), "public, max-age=86400");
+    // Vary must be exactly Accept-Encoding or Cloudflare skips edge caching.
+    assertEquals(res.headers.get("vary"), "Accept-Encoding");
+    assertEquals(res.headers.get("x-frame-options"), "SAMEORIGIN");
+    assertEquals(res.headers.get("x-content-type-options"), "nosniff");
+    // Upstream headers not overridden are preserved.
+    assertEquals(res.headers.get("x-custom-upstream"), "kept");
+    assertEquals(await res.text(), html);
+  });
+});
+
+describe("routes/api/v2/keys/index.ts", () => {
+  afterEach(() => restore());
+
+  const post = (email: string) =>
+    new Request("https://stampchain.io/api/v2/keys", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+
+  it("returns 409 DUPLICATE_EMAIL with no-store when the email already has a key", async () => {
+    const unsilence = silence();
+    try {
+      (globalThis as Record<string, unknown>).SKIP_REDIS_CONNECTION = true;
+      stub(
+        ApiKeyService,
+        "createKey",
+        () => Promise.reject(new Error("Duplicate entry 'x' for key 'email'")),
+      );
+
+      const res = await keysHandler.POST!(post("dupe@example.com"), {} as never);
+
+      assertEquals(res.status, 409);
+      assertEquals(res.headers.get("content-type"), "application/json");
+      assertEquals(res.headers.get("cache-control"), "no-store");
+      assertEquals(
+        await res.text(),
+        JSON.stringify({
+          error: "An API key already exists for this email address.",
+          code: "DUPLICATE_EMAIL",
+        }),
+      );
+    } finally {
+      unsilence();
+    }
+  });
+
+  it("signup rate-limit response keeps the 429 wire contract", async () => {
+    // The in-memory Redis fallback used under SKIP_REDIS_CONNECTION always
+    // returns incr=1, so the >3 branch is exercised through the exact helper
+    // call the route makes.
+    const res = ApiResponseUtil.custom(
+      {
+        error: "Too many signup attempts. Limit: 3 per hour per IP.",
+        retryAfter: 3600,
+      },
+      429,
+      {
+        forceNoCache: true,
+        headers: { "Retry-After": "3600", "Cache-Control": "no-store" },
+      },
+    );
+
+    assertEquals(res.status, 429);
+    assertEquals(res.headers.get("content-type"), "application/json");
+    assertEquals(res.headers.get("cache-control"), "no-store");
+    assertEquals(res.headers.get("retry-after"), "3600");
+    assertEquals(
+      await res.text(),
+      JSON.stringify({
+        error: "Too many signup attempts. Limit: 3 per hour per IP.",
+        retryAfter: 3600,
+      }),
+    );
+  });
+});
+
+describe("routes/api/_middleware.ts", () => {
+  it("maps a timeout to a 504 GATEWAY_TIMEOUT JSON body", async () => {
+    const unsilence = silence();
+    try {
+      const req = new Request("https://stampchain.io/api/v2/health");
+      const abort = new Error("aborted");
+      abort.name = "AbortError";
+      const ctx = {
+        state: {},
+        url: new URL(req.url),
+        next: () => Promise.reject(abort),
+      } as never;
+
+      const res = await apiMiddleware(req, ctx);
+
+      assertEquals(res.status, 504);
+      assertEquals(res.headers.get("content-type"), "application/json");
+      assertEquals(
+        await res.text(),
+        JSON.stringify({
+          status: "error",
+          message: "Request timeout - the operation took too long to complete",
+          error: "GATEWAY_TIMEOUT",
+        }),
+      );
+    } finally {
+      unsilence();
+    }
+  });
+});

--- a/tests/unit/webResponseUtil.test.ts
+++ b/tests/unit/webResponseUtil.test.ts
@@ -243,3 +243,77 @@ Deno.test("WebResponseUtil - cache headers with routeType", () => {
   assertExists(response.headers.get("Cache-Control"));
   assertExists(response.headers.get("Vary"));
 });
+
+Deno.test("WebResponseUtil - modifiedResponse overrides upstream headers case-insensitively", async () => {
+  const upstream = new Response("old", {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "vary": "Accept-Encoding, X-API-Version, Origin",
+      "cache-control": "public, max-age=31536000, immutable",
+      "x-upstream": "kept",
+    },
+  });
+
+  const response = WebResponseUtil.modifiedResponse("new", upstream, {
+    headers: {
+      "Cache-Control": "public, max-age=3600, no-transform",
+      "Vary": "Accept-Encoding",
+    },
+  });
+
+  assertEquals(response.status, 200);
+  assertEquals(await response.text(), "new");
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=3600, no-transform",
+  );
+  assertEquals(response.headers.get("x-upstream"), "kept");
+  // Default normalisation still appends the API-version vary keys.
+  assertEquals(
+    response.headers.get("vary"),
+    "Accept-Encoding, X-API-Version, Origin",
+  );
+});
+
+Deno.test("WebResponseUtil - modifiedResponse immutableBinary keeps Vary CDN-safe", () => {
+  const upstream = new Response("x", {
+    headers: { "vary": "Accept-Encoding, X-API-Version, Origin" },
+  });
+
+  const response = WebResponseUtil.modifiedResponse("y", upstream, {
+    headers: { "Vary": "Accept-Encoding" },
+    immutableBinary: true,
+  });
+
+  assertEquals(response.headers.get("vary"), "Accept-Encoding");
+});
+
+Deno.test("WebResponseUtil - xmlResponse sets XML content type and honours cache overrides", async () => {
+  const xml = '<?xml version="1.0"?><root/>';
+  const response = WebResponseUtil.xmlResponse(xml, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "CDN-Cache-Control": "public, max-age=3600",
+    },
+  });
+
+  assertEquals(response.status, 200);
+  assertEquals(
+    response.headers.get("content-type"),
+    "application/xml; charset=utf-8",
+  );
+  assertEquals(response.headers.get("cache-control"), "public, max-age=3600");
+  assertEquals(
+    response.headers.get("cdn-cache-control"),
+    "public, max-age=3600",
+  );
+  assertExists(response.headers.get("x-api-version"));
+  assertExists(response.headers.get("content-security-policy"));
+  assertEquals(await response.text(), xml);
+});
+
+Deno.test("WebResponseUtil - xmlResponse defaults to security-header cache policy", () => {
+  const response = WebResponseUtil.xmlResponse("<a/>", { forceNoCache: true });
+  assertEquals(response.headers.get("cache-control"), "no-store, must-revalidate");
+});


### PR DESCRIPTION
## Summary

`deno task check:responses` exited 1 on four manual `new Response()` constructions (plus one warning in an exception file), which blocked the `check:all` / `validate` / `validate:ci` task chains. Each site now goes through `ApiResponseUtil` / `WebResponseUtil` with the same status, content-type, cache headers and body bytes as before. The checker script is untouched; no allow-list entries were added.

Fixes #1223

## Per-site changes

| Site | Before | After |
|---|---|---|
| `routes/sitemap.xml.ts:61` | `new Response(xml, {Content-Type: application/xml; charset=utf-8, Cache-Control: public, max-age=3600})` | `WebResponseUtil.xmlResponse(xml, {headers})` (new helper). All five cache headers (`Cache-Control`, `CDN-Cache-Control`, `Cloudflare-CDN-Cache-Control`, `Surrogate-Control`, `Edge-Control`) pinned to the existing 1h TTL so the sitemap does not inherit the 1-year immutable default from `getSecurityHeaders`. |
| `routes/handlers/sharedContentHandler.ts:130` | copy upstream headers, override cache/Vary/XFO/XCTO, `new Response(body, {status, headers})` | `WebResponseUtil.modifiedResponse(body, response, {headers, immutableBinary: true})`. `immutableBinary` keeps `Vary: Accept-Encoding` exactly, which the handler relies on for Cloudflare edge caching. |
| `routes/api/v2/keys/index.ts:77` (429) | manual JSON body + `Retry-After: 3600`, `Cache-Control: no-store` | `ApiResponseUtil.custom(body, 429, {forceNoCache, headers: {Retry-After, Cache-Control: no-store}})`. Body unchanged (matches the `retryAfter` shape documented in `schema.yml`). |
| `routes/api/v2/keys/index.ts:111` (409) | manual JSON body `{error, code: DUPLICATE_EMAIL}` + `Cache-Control: no-store` | `ApiResponseUtil.custom(body, 409, {forceNoCache, headers: {Cache-Control: no-store}})`. Body unchanged. |
| `routes/api/_middleware.ts:181` (504, warning) | manual JSON body, `Content-Type: application/json` only | `ApiResponseUtil.custom(body, 504, {forceNoCache: true})`. Body unchanged. |

`ApiResponseUtil.custom` was chosen over `tooManyRequests()` / `conflict()` because those rewrite the body into the `{error, status, code}` envelope, which would change the documented 429/409 bodies.

## Helper changes (`lib/utils/api/responses/webResponseUtil.ts`)

- **`modifiedResponse`** now merges header overrides through a `Headers` object (case-insensitive) and honours `immutableBinary`. Previously an override such as `Vary` or `Content-Type` was silently dropped whenever the upstream response carried the lowercase key, because `normalizeHeaders` picks the first case-insensitive match. The single existing caller (`routes/_middleware.ts`, no overrides) is unaffected.
- **`xmlResponse`** added, mirroring `htmlResponse` for `application/xml`.

## Wire-level deltas (intentional, listed for review)

- All five sites now also carry the standard helper headers (`X-API-Version`, CSP, `X-Content-Type-Options`, etc.) and a normalised `Vary`. Status, content-type, `Cache-Control` and body are byte-identical.
- 429/409: `CDN-Cache-Control` / `Surrogate-Control` / `Edge-Control` now say `no-store` too. Same effect as the existing `Cache-Control: no-store`.
- 504: previously had no cache headers; now `no-store`. Browsers and Cloudflare do not cache 504s by default, so no observable change, and it matches the sibling `internalError()` branch.
- Sitemap: prod currently serves it `cf-cache-status: DYNAMIC`, so the added `Vary` values do not change CDN behaviour.

## Tests

- `tests/unit/routeResponseHelpers.test.ts` (new): calls each migrated route/handler and asserts status, content-type, cache headers and exact body. `sharedContentHandler` stubs `StampController.getStampFile`; the keys 409 path stubs `ApiKeyService.createKey`; the 504 path drives `routes/api/_middleware.ts` with a `next()` that rejects with an `AbortError`. The 429 branch is unreachable under the in-memory Redis fallback (`incr` always returns 1), so it is pinned via the identical helper call.
- `tests/unit/webResponseUtil.test.ts`: added cases for the `modifiedResponse` merge fix, `immutableBinary` Vary handling, and `xmlResponse`.

## Gates

```
deno task check:responses   -> No manual Response() usage found - all routes use utility methods!
deno fmt --check            -> Checked 615 files
deno lint                   -> Checked 722 files
deno check <changed files>  -> clean (5 source files + 2 test files)
deno task test:unit         -> ok | 1128 passed (2902 steps) | 0 failed | 7 ignored
```

## Follow-ups (out of scope, pre-existing)

- `WebResponseUtil.stampResponse` (text path) and `htmlResponse` spread a `Headers` instance (`{...headers}`), which yields nothing, so they silently drop the security headers and any caller `Cache-Control`. That is why `sharedContentHandler` already passes `Object.fromEntries(recursiveHeaders)` manually. Worth a separate fix.
- `routes/api/_middleware.ts` no longer has any manual `Response()`, so its entry in the checker's `EXCEPTIONS` list is now vestigial and could be removed to tighten the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
