### PR TITLE
fix(wallet): honour ordinalsAddress in owner checks and creator-name signing

### DIFF
--- a/client/wallet/wallet.ts
+++ b/client/wallet/wallet.ts
@@ -120,8 +120,8 @@ export const walletContext: WalletContext = {
   updateWallet,
   disconnect,
   getBasicStampInfo,
-  signMessage: async (message: string) => {
-    return await signMessage(walletContext.wallet, message);
+  signMessage: async (message: string, address?: string) => {
+    return await signMessage(walletContext.wallet, message, address);
   },
   signPSBT: async (
     wallet: Wallet,

--- a/client/wallet/walletHelper.ts
+++ b/client/wallet/walletHelper.ts
@@ -7,11 +7,18 @@ import { unisatProvider } from "$client/wallet/unisat.ts";
 import { wonderProvider } from "$client/wallet/wonder.ts";
 import { xverseProvider } from "$client/wallet/xverse.ts";
 import { logger } from "$lib/utils/logger.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import type { SignPSBTResult, Wallet } from "$types/index.d.ts";
 import type { PSBTInputToSign } from "$types/wallet.d.ts";
 
 interface WalletProvider {
-  signMessage: (message: string) => Promise<string>;
+  /**
+   * Sign `message`. `address` (optional) selects which of the wallet's own
+   * addresses signs; providers that expose a single address may ignore it —
+   * `signMessage()` below already guarantees it is one of the wallet's
+   * addresses before the provider is called.
+   */
+  signMessage: (message: string, address?: string) => Promise<string>;
   signPSBT: (
     psbtHex: string,
     inputsToSign: PSBTInputToSign[],
@@ -189,12 +196,30 @@ export const getWalletProvider = (
   }
 };
 
-export const signMessage = async (wallet: Wallet, message: string) => {
+/**
+ * Sign `message` with the connected wallet.
+ *
+ * @param address - Optional address that must produce the signature. Used when
+ *   an owner action targets a resource keyed by one of the wallet's secondary
+ *   addresses (e.g. the Xverse ordinals address). It MUST be an address the
+ *   wallet controls (see `walletOwnsAddress`); anything else is rejected here
+ *   so a provider is never asked to sign for a foreign address.
+ */
+export const signMessage = async (
+  wallet: Wallet,
+  message: string,
+  address?: string,
+) => {
   console.log("Signing message for wallet:", wallet.provider);
   console.log("Message to sign:", message);
   if (!wallet.provider) throw new Error("No wallet provider specified");
+  if (address !== undefined && !walletOwnsAddress(wallet, address)) {
+    throw new Error(
+      "Signing address is not controlled by the connected wallet",
+    );
+  }
   const provider = getWalletProvider(wallet.provider);
-  return await provider.signMessage(message);
+  return await provider.signMessage(message, address);
 };
 
 export const signPSBT = async (

--- a/client/wallet/xverse.ts
+++ b/client/wallet/xverse.ts
@@ -7,7 +7,7 @@
  * Capabilities:
  *   - Provider detection (checkXverse)
  *   - Wallet connection with payment (P2WPKH) and ordinals (P2TR) addresses (connectXverse)
- *   - Message signing via ECDSA (signMessage)
+ *   - Message signing via ECDSA, or BIP-322 for the ordinals address (signMessage)
  *   - PSBT signing with automatic hex/base64 conversion (signPSBT)
  *
  * PSBT format: stampchain.io uses hex internally; Xverse requires base64.
@@ -16,6 +16,10 @@
 
 import { walletContext } from "$client/wallet/wallet.ts";
 import { parseConnectionError } from "$client/wallet/walletHelper.ts";
+import {
+  resolveXverseSigningAddress,
+  xverseSigningProtocolFor,
+} from "$client/wallet/xverseSigning.ts";
 import { getBTCBalanceInfo } from "$lib/utils/data/processing/balanceUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
 import type { BaseToast } from "$lib/utils/ui/notifications/toastSignal.ts";
@@ -381,40 +385,51 @@ export const signPSBT = async (
 /**
  * Sign an arbitrary message with the connected Xverse wallet.
  *
- * Uses ECDSA signing via the Xverse BitcoinProvider.signMessage() API.
- * The wallet address is automatically retrieved from the walletContext signal.
+ * Signs with the payment address (ECDSA) by default. When `address` is the
+ * wallet's ordinals address the message is signed with that address using
+ * BIP-322 instead, so owner actions on resources keyed by the ordinals
+ * address can be verified against that address.
  *
  * Error codes:
  *   - USER_REJECTION (-32000 / 4001): re-thrown as-is for caller to handle
  *   - INVALID_PARAMS (-32602): re-thrown as-is for caller to handle
  *
  * @param message - Arbitrary UTF-8 message string to sign
+ * @param address - Optional address that must sign; must be one of the
+ *   connected wallet's addresses
  * @returns Base64-encoded signature string
  * @throws {Error} "Xverse wallet not installed" if extension is absent
  * @throws {Error} "Wallet not connected" if no address is in walletContext
+ * @throws {Error} if `address` is not controlled by the connected wallet
  * @throws {Error} "Unexpected response format from Xverse signMessage" for unknown responses
  */
-export const signMessage = async (message: string): Promise<string> => {
+export const signMessage = async (
+  message: string,
+  address?: string,
+): Promise<string> => {
   const provider = getXverseProvider();
   if (!provider) {
     throw new Error("Xverse wallet not installed");
   }
 
-  const walletAddress = walletContext.wallet.address;
-  if (!walletAddress) {
+  const wallet = walletContext.wallet;
+  if (!wallet.address) {
     throw new Error("Wallet not connected");
   }
+
+  const signingAddress = resolveXverseSigningAddress(wallet, address);
+  const protocol = xverseSigningProtocolFor(signingAddress);
 
   try {
     logger.debug("ui", {
       message: "Signing message with Xverse",
-      data: { messageLength: message.length },
+      data: { messageLength: message.length, protocol },
     });
 
     const response = await provider.signMessage({
-      address: walletAddress,
+      address: signingAddress,
       message,
-      protocol: "ECDSA",
+      protocol,
     });
 
     if (typeof response === "string") {
@@ -449,7 +464,7 @@ export const signMessage = async (message: string): Promise<string> => {
  * functions directly.
  *
  * Compatible with WalletProvider interface:
- *   - signMessage(message: string): Promise<string>
+ *   - signMessage(message: string, address?: string): Promise<string>
  *   - signPSBT(psbtHex, inputsToSign, enableRBF?, sighashTypes?, autoBroadcast?): Promise<SignPSBTResult>
  *   - broadcastRawTX?(rawTx: string): Promise<string>  [not supported]
  *   - broadcastPSBT?(psbtHex: string): Promise<string>  [not supported]

--- a/client/wallet/xverseSigning.ts
+++ b/client/wallet/xverseSigning.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helpers for choosing how the Xverse wallet signs a message.
+ *
+ * Kept free of the `xverse.ts` <-> `walletHelper.ts` <-> `wallet.ts` import
+ * cycle so they can be imported (and unit-tested) in isolation.
+ */
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
+import type { Wallet } from "$types/wallet.d.ts";
+
+export type XverseSigningProtocol = "ECDSA" | "BIP322";
+
+/**
+ * Pick which of the connected Xverse addresses signs a message.
+ *
+ * Defaults to the payment address. A caller may request the ordinals address
+ * (or, redundantly, the payment address) — anything the wallet does not
+ * control is rejected so we never ask Xverse to sign for a foreign address.
+ */
+export const resolveXverseSigningAddress = (
+  wallet: Pick<Wallet, "address" | "ordinalsAddress" | "accounts">,
+  address?: string,
+): string => {
+  if (address === undefined) return wallet.address;
+  if (!walletOwnsAddress(wallet, address)) {
+    throw new Error(
+      "Signing address is not controlled by the connected Xverse wallet",
+    );
+  }
+  return address;
+};
+
+/**
+ * Xverse only supports ECDSA message signing for its payment address
+ * (P2WPKH / P2SH). Taproot (P2TR, `bc1p…`) addresses must sign with BIP-322,
+ * which the server-side verifier (`verifySignature` in cryptoUtils) accepts.
+ */
+export const xverseSigningProtocolFor = (
+  signingAddress: string,
+): XverseSigningProtocol => {
+  return /^(bc|tb|bcrt)1p/i.test(signingAddress) ? "BIP322" : "ECDSA";
+};

--- a/islands/header/WalletHeader.tsx
+++ b/islands/header/WalletHeader.tsx
@@ -15,6 +15,7 @@ import {
   formatBTCAmount,
 } from "$lib/utils/ui/formatting/formatUtils.ts";
 import { showToast } from "$lib/utils/ui/notifications/toastSignal.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import { tooltipIcon } from "$notification";
 import { subtitlePrimary, text, titlePrimary, valueSm } from "$text";
 import type { WalletHeaderProps } from "$types/ui.d.ts";
@@ -95,6 +96,7 @@ function WalletOverview({ walletData }: { walletData: WalletOverviewInfo }) {
   const handleEditClick = () => {
     openModal(
       <EditCreatorNameModal
+        address={walletData.address}
         currentName={walletData.creatorName || ""}
         onSuccess={(newName) => {
           setDisplayName(newName);
@@ -120,9 +122,10 @@ function WalletOverview({ walletData }: { walletData: WalletOverviewInfo }) {
     walletData.creatorName !== `${name}.btc`
   );
 
-  // Check if the connected wallet owns this profile
-  const isOwner = wallet?.address &&
-    wallet.address.toLowerCase() === walletData.address.toLowerCase();
+  // Check if the connected wallet owns this profile. Goes through the
+  // canonical helper so secondary addresses (e.g. the Xverse ordinals
+  // address) are recognised as well as the primary payment address.
+  const isOwner = walletOwnsAddress(wallet, walletData.address);
 
   /* ===== RENDER ===== */
   return (

--- a/islands/modal/EditCreatorNameModal.tsx
+++ b/islands/modal/EditCreatorNameModal.tsx
@@ -7,6 +7,7 @@ import { ModalBase } from "$layout";
 import { logger } from "$lib/utils/logger.ts";
 import { getCSRFToken } from "$lib/utils/security/clientSecurityUtils.ts";
 import { showToast } from "$lib/utils/ui/notifications/toastSignal.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import { labelSm } from "$text";
 import { useState } from "preact/hooks";
 
@@ -17,6 +18,12 @@ const CREATOR_NAME_PATTERN = /^[a-zA-Z0-9 .\-_']+$/;
 
 /* ===== TYPES ===== */
 export interface EditCreatorNameModalProps {
+  /**
+   * Address whose creator name is being edited (the profile being viewed).
+   * Must be one of the connected wallet's addresses — payment or ordinals —
+   * and is the address that signs the update and that the server verifies.
+   */
+  address: string;
   currentName?: string;
   onSuccess?: (newName: string) => void;
 }
@@ -52,6 +59,7 @@ export function validateCreatorName(
 
 /* ===== COMPONENT ===== */
 function EditCreatorNameModal({
+  address,
   currentName,
   onSuccess,
 }: EditCreatorNameModalProps) {
@@ -94,6 +102,16 @@ function EditCreatorNameModal({
       return;
     }
 
+    // Guard: the profile address must belong to the connected wallet
+    // (payment or ordinals address). Never sign/submit for a foreign address.
+    if (!walletOwnsAddress(wallet, address)) {
+      showToast(
+        "The connected wallet does not control this address",
+        "error",
+      );
+      return;
+    }
+
     // Client-side validation
     const validation = validateCreatorName(newName);
     if (!validation.valid) {
@@ -130,9 +148,12 @@ function EditCreatorNameModal({
         component: "EditCreatorNameModal",
       });
 
+      // Sign with the profile address itself, so the server-side check
+      // (signature must verify against the address being updated) holds for
+      // secondary addresses such as the Xverse ordinals address.
       let signature: string;
       try {
-        const rawSignature = await walletContext.signMessage(message);
+        const rawSignature = await walletContext.signMessage(message, address);
         console.log(
           "[EditCreatorName] signMessage returned:",
           typeof rawSignature,
@@ -169,7 +190,7 @@ function EditCreatorNameModal({
       // Step 3: POST to API
       logger.debug("ui", {
         message: "Submitting creator name update",
-        address: wallet.address,
+        address,
         newName: trimmedName,
         component: "EditCreatorNameModal",
       });
@@ -181,7 +202,7 @@ function EditCreatorNameModal({
           "X-CSRF-Token": csrfToken,
         },
         body: JSON.stringify({
-          address: wallet.address,
+          address,
           newName: trimmedName,
           signature,
           timestamp,

--- a/islands/table/UploadImageTable.tsx
+++ b/islands/table/UploadImageTable.tsx
@@ -6,6 +6,7 @@ import {
   formatDate,
 } from "$lib/utils/ui/formatting/formatUtils.ts";
 import { getSRC20ImageSrc } from "$lib/utils/ui/media/imageUtils.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import { textLg } from "$text";
 import type { WalletDataTypes } from "$types/base.d.ts";
 import type { SRC20Row } from "$types/src20.d.ts";
@@ -39,6 +40,11 @@ export const UploadImageTable = (props: SRC20BalanceTableProps) => {
   // PERFORMANCE OPTIMIZATION: Use wallet signal instead of polling localStorage
   // This eliminates the 1-second polling that was consuming CPU resources
   const wallet = walletSignal.value as WalletDataTypes;
+  // Tokens deployed by any of the connected wallet's addresses (payment or
+  // ordinals) — see lib/utils/wallet/ownership.ts.
+  const ownedRows = data.filter((row) =>
+    walletOwnsAddress(walletSignal.value, row.creator)
+  );
 
   /* ===== EVENT HANDLERS ===== */
   const handleCloseModal = () => {
@@ -80,7 +86,7 @@ export const UploadImageTable = (props: SRC20BalanceTableProps) => {
                 </tr>
               </thead>
               <tbody>
-                {data.filter((row) => row.creator === wallet.address).map(
+                {ownedRows.map(
                   // data.map(
                   (src20: SRC20Row) => {
                     const href = `/upload/${unicodeEscapeToEmoji(src20.tick)}`;

--- a/lib/types/ui.d.ts
+++ b/lib/types/ui.d.ts
@@ -4112,7 +4112,7 @@ export interface WalletContext {
   updateWallet: (wallet: Wallet) => void;
   getBasicStampInfo: (address: string) => Promise<any>;
   disconnect: () => void;
-  signMessage: (message: string) => Promise<any>;
+  signMessage: (message: string, address?: string) => Promise<any>;
   signPSBT: (
     wallet: Wallet,
     psbt: string,

--- a/lib/utils/wallet/ownership.ts
+++ b/lib/utils/wallet/ownership.ts
@@ -1,0 +1,90 @@
+/* ===== WALLET OWNERSHIP HELPERS ===== */
+/**
+ * Canonical "does the connected wallet control this address?" logic.
+ *
+ * Wallets can expose more than one address for the same session. Xverse, for
+ * example, reports a payment address (P2WPKH, `bc1q…`) on `wallet.address`
+ * and an ordinals address (P2TR, `bc1p…`) on `wallet.ordinalsAddress`, and
+ * lists both in `wallet.accounts`. Any owner-gated decision (owner-only UI,
+ * "is this my stamp/token", which address to sign with, …) MUST go through
+ * these helpers instead of comparing `wallet.address` directly, otherwise the
+ * secondary addresses are silently ignored.
+ *
+ * Comparison rules:
+ *   - Bech32 / Bech32m addresses (`bc1…`, `tb1…`, `bcrt1…`) are case-insensitive
+ *     by spec, so they are compared case-insensitively.
+ *   - Base58Check addresses (`1…`, `3…`, `m…`, `n…`, `2…`) are case-sensitive,
+ *     so they are compared exactly.
+ *   - Surrounding whitespace is never significant.
+ */
+import type { Wallet } from "$types/wallet.d.ts";
+
+/** Minimal shape needed to enumerate the addresses a wallet controls. */
+export type WalletAddressSource = Partial<
+  Pick<Wallet, "address" | "ordinalsAddress" | "accounts">
+>;
+
+const BECH32_PREFIX = /^(bc|tb|bcrt)1/i;
+
+function normalizeAddress(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Compare two Bitcoin addresses for equality, honouring the case rules of
+ * each address format (see module docs).
+ */
+export function addressesEqual(a: unknown, b: unknown): boolean {
+  const left = normalizeAddress(a);
+  const right = normalizeAddress(b);
+  if (left === null || right === null) return false;
+  if (left === right) return true;
+  if (BECH32_PREFIX.test(left) && BECH32_PREFIX.test(right)) {
+    return left.toLowerCase() === right.toLowerCase();
+  }
+  return false;
+}
+
+/**
+ * All distinct, non-empty addresses the connected wallet reports as its own:
+ * the primary/payment address, the optional ordinals address, and every entry
+ * of `accounts`. Order is preserved (primary first) and duplicates removed.
+ */
+export function getWalletAddresses(
+  wallet: WalletAddressSource | null | undefined,
+): string[] {
+  if (!wallet) return [];
+  const candidates: unknown[] = [
+    wallet.address,
+    wallet.ordinalsAddress,
+    ...(Array.isArray(wallet.accounts) ? wallet.accounts : []),
+  ];
+  const result: string[] = [];
+  for (const candidate of candidates) {
+    const normalized = normalizeAddress(candidate);
+    if (normalized === null) continue;
+    if (result.some((existing) => addressesEqual(existing, normalized))) {
+      continue;
+    }
+    result.push(normalized);
+  }
+  return result;
+}
+
+/**
+ * True when `address` is one of the addresses controlled by `wallet`.
+ * Returns false for a missing wallet, a disconnected wallet (no addresses),
+ * or an empty/invalid target address.
+ */
+export function walletOwnsAddress(
+  wallet: WalletAddressSource | null | undefined,
+  address: unknown,
+): boolean {
+  const target = normalizeAddress(address);
+  if (target === null) return false;
+  return getWalletAddresses(wallet).some((owned) =>
+    addressesEqual(owned, target)
+  );
+}

--- a/tests/unit/cryptoUtils.bip322-p2tr.test.ts
+++ b/tests/unit/cryptoUtils.bip322-p2tr.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Server-side signature verification for owner actions signed with a
+ * taproot (P2TR) address, as produced by Xverse's ordinals address via
+ * BIP-322. Guards the contract relied on by EditCreatorNameModal: the
+ * signature must verify against the *resource* address being updated, and
+ * a signature from one of the wallet's addresses must never verify against
+ * another of its addresses.
+ *
+ * Vectors were generated once with bip322-js Signer from a throwaway key;
+ * verification is deterministic so they are embedded as fixtures.
+ */
+
+import { assertEquals } from "@std/assert";
+import { verifySignature } from "$lib/utils/security/cryptoUtils.ts";
+
+const MESSAGE = "Update creator name to Alice at 1700000000000";
+const P2TR = "bc1pr4zzasskelxqqqurj7pelzrcufrxl4kjqxn5zk0uaafkpt5ndtdq8t8w76";
+const P2WPKH = "bc1ql9y6eq0amutq8yhvuuhwrp68shg9r2979ecluw";
+const P2TR_BIP322_SIG =
+  "AUFxE/c+HJy8KIJI78VuvBAUWcsRPoX+cQZ+I7hX3Ask1iHGpmv6Tg9ytCva8hMKsLGAJWhMdij3DmL89Jzy1Q76AQ==";
+const P2WPKH_BIP322_SIG =
+  "AkcwRAIgYmvpu8cox1sRJVZ8gt8Hz5dWVnZh12Edq3oPUpVzqToCIDkcbD/W1Myb9t80hOHwcEXawzSaxseKTLj3tAP9ZRGVASECU0VpPw96QfHpm9Ns0/ilY74g/hMLzdjwzss85M5Hilc=";
+
+const originalConsoleError = console.error;
+
+function withQuietConsole(fn: () => void) {
+  console.error = () => {};
+  try {
+    fn();
+  } finally {
+    console.error = originalConsoleError;
+  }
+}
+
+Deno.test("verifySignature: accepts a BIP-322 signature from a P2TR (ordinals) address", () => {
+  assertEquals(verifySignature(MESSAGE, P2TR_BIP322_SIG, P2TR), true);
+});
+
+Deno.test("verifySignature: accepts a BIP-322 signature from a P2WPKH (payment) address", () => {
+  assertEquals(verifySignature(MESSAGE, P2WPKH_BIP322_SIG, P2WPKH), true);
+});
+
+Deno.test("verifySignature: P2TR signature does not verify against the sibling payment address", () => {
+  withQuietConsole(() => {
+    assertEquals(verifySignature(MESSAGE, P2TR_BIP322_SIG, P2WPKH), false);
+  });
+});
+
+Deno.test("verifySignature: payment signature does not verify against the sibling P2TR address", () => {
+  withQuietConsole(() => {
+    assertEquals(verifySignature(MESSAGE, P2WPKH_BIP322_SIG, P2TR), false);
+  });
+});
+
+Deno.test("verifySignature: P2TR signature rejects a tampered message", () => {
+  withQuietConsole(() => {
+    assertEquals(verifySignature(MESSAGE + "!", P2TR_BIP322_SIG, P2TR), false);
+  });
+});

--- a/tests/unit/wallet/ownership.test.ts
+++ b/tests/unit/wallet/ownership.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for lib/utils/wallet/ownership.ts
+ *
+ * The helper is the single source of truth for "does the connected wallet
+ * control this address?". Dual-address wallets (Xverse) expose a payment
+ * address on `wallet.address` and an ordinals address on
+ * `wallet.ordinalsAddress`; both must be recognised as owned.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  addressesEqual,
+  getWalletAddresses,
+  walletOwnsAddress,
+} from "$lib/utils/wallet/ownership.ts";
+
+const PAYMENT = "bc1ql9y6eq0amutq8yhvuuhwrp68shg9r2979ecluw";
+const ORDINALS =
+  "bc1pr4zzasskelxqqqurj7pelzrcufrxl4kjqxn5zk0uaafkpt5ndtdq8t8w76";
+const OTHER = "bc1qpayment123abcdefghijklmnopqrstuvwxyz0123456";
+const LEGACY = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2";
+const LEGACY_RECASED = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVn2";
+
+const xverseWallet = {
+  address: PAYMENT,
+  ordinalsAddress: ORDINALS,
+  accounts: [PAYMENT, ORDINALS],
+};
+
+const singleAddressWallet = {
+  address: PAYMENT,
+  accounts: [PAYMENT],
+};
+
+// ============================================================================
+// walletOwnsAddress
+// ============================================================================
+
+Deno.test("walletOwnsAddress: matches the payment address", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, PAYMENT), true);
+  assertEquals(walletOwnsAddress(singleAddressWallet, PAYMENT), true);
+});
+
+Deno.test("walletOwnsAddress: matches the ordinals address (Xverse)", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, ORDINALS), true);
+});
+
+Deno.test("walletOwnsAddress: rejects an address the wallet does not control", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, OTHER), false);
+  assertEquals(walletOwnsAddress(singleAddressWallet, ORDINALS), false);
+});
+
+Deno.test("walletOwnsAddress: false for missing ordinalsAddress on single-address wallets", () => {
+  const wallet = { address: PAYMENT, accounts: [] as string[] };
+  assertEquals(walletOwnsAddress(wallet, PAYMENT), true);
+  assertEquals(walletOwnsAddress(wallet, ORDINALS), false);
+});
+
+Deno.test("walletOwnsAddress: false for null / undefined / disconnected wallet", () => {
+  assertEquals(walletOwnsAddress(null, PAYMENT), false);
+  assertEquals(walletOwnsAddress(undefined, PAYMENT), false);
+  assertEquals(walletOwnsAddress({}, PAYMENT), false);
+  assertEquals(
+    walletOwnsAddress({ address: "", accounts: [] }, PAYMENT),
+    false,
+  );
+  assertEquals(walletOwnsAddress({ address: "", accounts: [] }, ""), false);
+});
+
+Deno.test("walletOwnsAddress: false for empty / non-string target address", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, ""), false);
+  assertEquals(walletOwnsAddress(xverseWallet, "   "), false);
+  assertEquals(walletOwnsAddress(xverseWallet, undefined), false);
+  assertEquals(walletOwnsAddress(xverseWallet, null), false);
+  assertEquals(walletOwnsAddress(xverseWallet, 42), false);
+});
+
+Deno.test("walletOwnsAddress: an empty wallet address never matches an empty target", () => {
+  // Guards against "" === "" treating a disconnected wallet as owner.
+  assertEquals(walletOwnsAddress({ address: "" }, ""), false);
+});
+
+Deno.test("walletOwnsAddress: recognises addresses only present in accounts", () => {
+  const wallet = { address: PAYMENT, accounts: [PAYMENT, ORDINALS] };
+  assertEquals(walletOwnsAddress(wallet, ORDINALS), true);
+});
+
+Deno.test("walletOwnsAddress: ignores non-string entries in accounts", () => {
+  const wallet = {
+    address: PAYMENT,
+    accounts: [PAYMENT, undefined, null, 7] as unknown as string[],
+  };
+  assertEquals(walletOwnsAddress(wallet, PAYMENT), true);
+  assertEquals(walletOwnsAddress(wallet, "7"), false);
+});
+
+Deno.test("walletOwnsAddress: bech32 comparison is case-insensitive", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, PAYMENT.toUpperCase()), true);
+  assertEquals(walletOwnsAddress(xverseWallet, ORDINALS.toUpperCase()), true);
+  assertEquals(
+    walletOwnsAddress({ address: PAYMENT.toUpperCase() }, PAYMENT),
+    true,
+  );
+});
+
+Deno.test("walletOwnsAddress: base58 (legacy) comparison is case-sensitive", () => {
+  const legacyWallet = { address: LEGACY, accounts: [LEGACY] };
+  assertEquals(walletOwnsAddress(legacyWallet, LEGACY), true);
+  assertEquals(walletOwnsAddress(legacyWallet, LEGACY_RECASED), false);
+  assertEquals(walletOwnsAddress(legacyWallet, LEGACY.toLowerCase()), false);
+});
+
+Deno.test("walletOwnsAddress: surrounding whitespace is not significant", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, `  ${ORDINALS}\n`), true);
+  assertEquals(walletOwnsAddress({ address: ` ${PAYMENT} ` }, PAYMENT), true);
+});
+
+// ============================================================================
+// getWalletAddresses
+// ============================================================================
+
+Deno.test("getWalletAddresses: returns payment first, then ordinals, deduplicated", () => {
+  assertEquals(getWalletAddresses(xverseWallet), [PAYMENT, ORDINALS]);
+});
+
+Deno.test("getWalletAddresses: single-address wallet yields one entry", () => {
+  assertEquals(getWalletAddresses(singleAddressWallet), [PAYMENT]);
+});
+
+Deno.test("getWalletAddresses: drops empty strings and non-strings", () => {
+  const wallet = {
+    address: "",
+    ordinalsAddress: ORDINALS,
+    accounts: ["", " ", ORDINALS, 5 as unknown as string],
+  };
+  assertEquals(getWalletAddresses(wallet), [ORDINALS]);
+});
+
+Deno.test("getWalletAddresses: dedupes bech32 case variants", () => {
+  const wallet = { address: PAYMENT, accounts: [PAYMENT.toUpperCase()] };
+  assertEquals(getWalletAddresses(wallet), [PAYMENT]);
+});
+
+Deno.test("getWalletAddresses: empty for null / undefined / empty wallet", () => {
+  assertEquals(getWalletAddresses(null), []);
+  assertEquals(getWalletAddresses(undefined), []);
+  assertEquals(getWalletAddresses({}), []);
+});
+
+// ============================================================================
+// addressesEqual
+// ============================================================================
+
+Deno.test("addressesEqual: exact match", () => {
+  assertEquals(addressesEqual(PAYMENT, PAYMENT), true);
+  assertEquals(addressesEqual(LEGACY, LEGACY), true);
+});
+
+Deno.test("addressesEqual: bech32 case-insensitive, base58 case-sensitive", () => {
+  assertEquals(addressesEqual(PAYMENT, PAYMENT.toUpperCase()), true);
+  assertEquals(addressesEqual("tb1qabc", "TB1QABC"), true);
+  assertEquals(addressesEqual(LEGACY, LEGACY_RECASED), false);
+});
+
+Deno.test("addressesEqual: different addresses and invalid inputs are not equal", () => {
+  assertEquals(addressesEqual(PAYMENT, ORDINALS), false);
+  assertEquals(addressesEqual(PAYMENT, ""), false);
+  assertEquals(addressesEqual("", ""), false);
+  assertEquals(addressesEqual(undefined, undefined), false);
+  assertEquals(addressesEqual(null, PAYMENT), false);
+  assertEquals(addressesEqual(1, 1), false);
+});

--- a/tests/unit/wallet/xverseSigning.test.ts
+++ b/tests/unit/wallet/xverseSigning.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for client/wallet/xverseSigning.ts — selection of the signing
+ * address and protocol used by Xverse `signMessage()`.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  resolveXverseSigningAddress,
+  xverseSigningProtocolFor,
+} from "$client/wallet/xverseSigning.ts";
+
+const PAYMENT = "bc1ql9y6eq0amutq8yhvuuhwrp68shg9r2979ecluw";
+const ORDINALS =
+  "bc1pr4zzasskelxqqqurj7pelzrcufrxl4kjqxn5zk0uaafkpt5ndtdq8t8w76";
+const FOREIGN =
+  "bc1pforeign0000000000000000000000000000000000000000000000000000";
+
+const wallet = {
+  address: PAYMENT,
+  ordinalsAddress: ORDINALS,
+  accounts: [PAYMENT, ORDINALS],
+};
+
+Deno.test("resolveXverseSigningAddress: defaults to the payment address", () => {
+  assertEquals(resolveXverseSigningAddress(wallet), PAYMENT);
+  assertEquals(resolveXverseSigningAddress(wallet, undefined), PAYMENT);
+});
+
+Deno.test("resolveXverseSigningAddress: allows the payment address explicitly", () => {
+  assertEquals(resolveXverseSigningAddress(wallet, PAYMENT), PAYMENT);
+});
+
+Deno.test("resolveXverseSigningAddress: allows the ordinals address", () => {
+  assertEquals(resolveXverseSigningAddress(wallet, ORDINALS), ORDINALS);
+});
+
+Deno.test("resolveXverseSigningAddress: rejects an address the wallet does not control", () => {
+  assertThrows(
+    () => resolveXverseSigningAddress(wallet, FOREIGN),
+    Error,
+    "not controlled by the connected Xverse wallet",
+  );
+  assertThrows(
+    () => resolveXverseSigningAddress(wallet, ""),
+    Error,
+    "not controlled by the connected Xverse wallet",
+  );
+});
+
+Deno.test("resolveXverseSigningAddress: rejects ordinals address on a wallet without one", () => {
+  const single = { address: PAYMENT, accounts: [PAYMENT] };
+  assertThrows(() => resolveXverseSigningAddress(single, ORDINALS), Error);
+});
+
+Deno.test("xverseSigningProtocolFor: ECDSA for the payment (P2WPKH) address", () => {
+  assertEquals(xverseSigningProtocolFor(PAYMENT), "ECDSA");
+  assertEquals(
+    xverseSigningProtocolFor("3P14159f73E4gFr7JterCCQh9QjiTjiZrG"),
+    "ECDSA",
+  );
+});
+
+Deno.test("xverseSigningProtocolFor: BIP322 for taproot (P2TR) addresses", () => {
+  assertEquals(xverseSigningProtocolFor(ORDINALS), "BIP322");
+  assertEquals(xverseSigningProtocolFor(ORDINALS.toUpperCase()), "BIP322");
+  assertEquals(xverseSigningProtocolFor("tb1p" + "q".repeat(58)), "BIP322");
+});


### PR DESCRIPTION
Fixes #1207

## Problem

Owner-gated UI decided "is the visitor the owner of this wallet/profile" by comparing only `wallet.address` (the payment address) against the page address. Dual-address wallets (Xverse: payment `bc1q…` + ordinals `bc1p…`) populate `wallet.ordinalsAddress`, but nothing read it, so a user on their own ordinals-address profile never saw the "Edit creator name" control.

There was a second, latent bug behind the first: `EditCreatorNameModal` always signed with and submitted `wallet.address`. Had the pencil icon simply been un-hidden, editing the ordinals profile would have silently updated the *payment* address's creator name instead.

## Ownership-check sites found and changed

| Site | Before | After |
|---|---|---|
| `islands/header/WalletHeader.tsx:124` (`isOwner`) | `wallet.address.toLowerCase() === walletData.address.toLowerCase()` | `walletOwnsAddress(wallet, walletData.address)`; passes `address={walletData.address}` to the modal |
| `islands/modal/EditCreatorNameModal.tsx` (submit) | signed via `walletContext.signMessage(message)` (payment address), POSTed `address: wallet.address` | new required `address` prop (the profile address); guards `walletOwnsAddress(wallet, address)`; signs with `walletContext.signMessage(message, address)`; POSTs `address` |
| `islands/table/UploadImageTable.tsx:83` ("my deployed tokens" filter) | `row.creator === wallet.address` | `walletOwnsAddress(walletSignal.value, row.creator)` |

Reviewed and deliberately left alone: `client/wallet/unisat.ts:67` and `client/wallet/wonder.ts:115` (accounts-changed "same address, skip re-connect" checks, not ownership); `client/wallet/horizon.ts:238`, `server/services/transaction/bitcoinTransactionBuilder.ts:188/520`, `server/services/stamp/stampCreationService.ts:736` (address-derivation / output-classification equality, not ownership); `routes/api/v2/trx/create_psbt.ts:28` (commented-out code).

## Canonical helper

`lib/utils/wallet/ownership.ts`:
- `walletOwnsAddress(wallet, address)` — true when `address` is any of `wallet.address`, `wallet.ordinalsAddress`, or an entry of `wallet.accounts`.
- `getWalletAddresses(wallet)` / `addressesEqual(a, b)`.
- Bech32/Bech32m addresses are compared case-insensitively (per spec); Base58Check addresses are compared exactly (addresses the issue's secondary observation). Empty/missing values never match, so a disconnected wallet (`address: ""`) is never an owner.

## Signing with the ordinals address (server verification unchanged)

Server-side `CreatorService.updateCreatorName` verifies the signature against the submitted `address` and updates that same address, so the invariant "signing address == resource address" already holds. No loosening. What was missing was the client's ability to sign with the ordinals address at all:

- `walletContext.signMessage(message, address?)` → `walletHelper.signMessage(wallet, message, address?)` (rejects any `address` the wallet does not control) → `provider.signMessage(message, address?)`.
- Xverse: signs the P2TR ordinals address with `protocol: "BIP322"` (Xverse ECDSA is payment-address only); payment address keeps ECDSA. Pure helpers in `client/wallet/xverseSigning.ts` (kept out of the xverse/walletHelper/wallet import cycle so they are testable).
- Single-address providers ignore the extra parameter; the helper guard guarantees it equals their only address.
- Verified `lib/utils/security/cryptoUtils.ts#verifySignature` accepts a BIP-322 P2TR signature (via bip322-js) and rejects it against the sibling payment address, and vice versa — captured as fixtures in `tests/unit/cryptoUtils.bip322-p2tr.test.ts`.

## Tests

- `tests/unit/wallet/ownership.test.ts` — payment match, ordinals match, mismatch, missing/empty fields, accounts-only match, bech32 case-insensitivity, base58 case-sensitivity, whitespace.
- `tests/unit/wallet/xverseSigning.test.ts` — signing-address resolution (default, payment, ordinals, foreign → throws) and protocol selection.
- `tests/unit/cryptoUtils.bip322-p2tr.test.ts` — server verifier accepts P2TR BIP-322, rejects cross-address and tampered message.

## Gates

```
deno fmt --check   → Checked 617 files (exit 0)
deno lint          → Checked 724 files (exit 0)
deno check <9 changed source files> → all Check, exit 0
deno task test:unit → ok | 1152 passed (2897 steps) | 0 failed | 7 ignored (37s)
```

Note: `deno task test:unit` runs with `--parallel` and is flaky on untouched files (leak / console-capture races); an untouched `origin/dev` worktree showed the same behaviour (1 of 2 runs failed on `generalBitcoinTransactionBuilder.test.ts`). Every file that flaked on this branch (`logger`, `esploraFetch`, `creatorService`) passes in isolation and imports nothing changed here.

## Remaining risk

- Xverse `protocol: "BIP322"` for the ordinals address has not been exercised against a live extension in this PR (no browser here). The server side is proven; if Xverse rejects the request the user gets the existing "Signing failed" toast and nothing is written.
- `EditCreatorNameModal` now requires an `address` prop; `WalletHeader` is its only caller.
