### PR TITLE
fix(api): bound the BTC leg of /api/v2/balance/{address} with one deadline + a handler ceiling (task 1217, #1198)

### DIFF
--- a/lib/types/utils.d.ts
+++ b/lib/types/utils.d.ts
@@ -294,6 +294,12 @@ export interface BTCBalanceInfoOptions {
   minConfirmations?: number;
   address?: string;
   includeUSD?: boolean;
+  /**
+   * Total wall-clock budget (ms) for the whole BTC-balance provider chain —
+   * every provider, retry and body read combined. Defaults to
+   * `DEFAULT_BTC_BALANCE_TIMEOUT_MS` in balanceUtils.
+   */
+  timeoutMs?: number;
 }
 
 /**

--- a/lib/utils/bitcoin/network/mempool.ts
+++ b/lib/utils/bitcoin/network/mempool.ts
@@ -1,4 +1,5 @@
 const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
 import { MEMPOOL_API_BASE_URL } from "$constants";
 import type { BTCBalance, MempoolAddressResponse } from "$lib/types/index.d.ts";
 
@@ -6,6 +7,21 @@ import type { BTCBalance, MempoolAddressResponse } from "$lib/types/index.d.ts";
 // upstream (mempool.space / BlockCypher) blocks the caller indefinitely — this
 // is what hung the aggregate `/api/v2/balance/{address}` endpoint (#1198).
 export const DEFAULT_FETCH_TIMEOUT_MS = 5000;
+
+function makeTimeoutError(timeoutMs: number): Error {
+  const timeoutError = new Error(`Request timed out after ${timeoutMs}ms`);
+  timeoutError.name = "TimeoutError";
+  return timeoutError;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+/** `true` when `error` is the `TimeoutError` thrown by the helpers below. */
+export function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
 
 /**
  * `fetch` with an `AbortController` deadline so a slow/unresponsive upstream
@@ -22,11 +38,46 @@ export async function fetchWithTimeout(
   try {
     return await fetch(input, { ...init, signal: controller.signal });
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      const timeoutError = new Error(`Request timed out after ${timeoutMs}ms`);
-      timeoutError.name = "TimeoutError";
-      throw timeoutError;
+    if (isAbortError(error)) throw makeTimeoutError(timeoutMs);
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export interface JsonFetchResult<T> {
+  ok: boolean;
+  status: number;
+  /** Parsed body when `ok`; `null` for non-2xx responses. */
+  data: T | null;
+}
+
+/**
+ * Like `fetchWithTimeout`, but the deadline covers the *whole* exchange —
+ * headers AND body. `fetchWithTimeout` disarms its timer as soon as `fetch()`
+ * resolves (headers received), so a `response.json()` issued afterwards is
+ * unbounded again. Here the abort signal stays armed until the body has been
+ * parsed; aborting mid-read rejects the body stream, which is mapped to the
+ * same `TimeoutError`. Non-2xx responses are drained and returned with
+ * `data: null` so callers can decide whether to retry.
+ */
+export async function fetchJsonWithTimeout<T>(
+  input: string | URL,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+  init: RequestInit = {},
+): Promise<JsonFetchResult<T>> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(input, { ...init, signal: controller.signal });
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => {});
+      return { ok: false, status: response.status, data: null };
     }
+    const data = await response.json() as T;
+    return { ok: true, status: response.status, data };
+  } catch (error) {
+    if (isAbortError(error)) throw makeTimeoutError(timeoutMs);
     throw error;
   } finally {
     clearTimeout(timeoutId);
@@ -118,20 +169,37 @@ export const getTransactionInfo = async (
   }
 };
 
+/**
+ * Fetch the BTC balance of `address` from mempool.space.
+ *
+ * `deadlineAt` (epoch ms) bounds the WHOLE call — every attempt, every retry
+ * back-off, and the body read — so the worst case is `deadlineAt - now`, not
+ * `MAX_RETRIES x per-fetch timeout + back-offs`. Before this the per-fetch
+ * deadline added by #1206 still let a provider that answered 429/5xx (a
+ * non-timeout error) retry 4 x 5s + 3 x 1s ~= 23s, which is exactly what the
+ * aggregate `/api/v2/balance/{address}` endpoint was measured at (#1198).
+ */
 export const getBTCBalanceFromMempool = async (
   address: string,
   retries = 0,
+  deadlineAt: number = Date.now() + DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<BTCBalance | null> => {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) return null;
+
+  const endpoint = `${MEMPOOL_API_BASE_URL}/address/${address}`;
   try {
-    const endpoint = `${MEMPOOL_API_BASE_URL}/address/${address}`;
-    const response = await fetchWithTimeout(endpoint);
-    if (!response.ok) {
+    const result = await fetchJsonWithTimeout<MempoolAddressResponse>(
+      endpoint,
+      Math.min(remaining, DEFAULT_FETCH_TIMEOUT_MS),
+    );
+    if (!result.ok || !result.data) {
       throw new Error(
-        `Error: response for: ${endpoint} unsuccessful. Response: ${response.status}`,
+        `Error: response for: ${endpoint} unsuccessful. Response: ${result.status}`,
       );
     }
 
-    const data = await response.json() as MempoolAddressResponse;
+    const data = result.data;
     const confirmed = data.chain_stats.funded_txo_sum -
       data.chain_stats.spent_txo_sum;
     const unconfirmed = data.mempool_stats.funded_txo_sum -
@@ -148,16 +216,20 @@ export const getBTCBalanceFromMempool = async (
     // A timeout means the upstream is unresponsive; retrying just re-accumulates
     // the delay (MAX_RETRIES x timeout) — exactly what let this hang the aggregate
     // balance endpoint (#1198). Fail fast so the caller can fall through / degrade.
-    if (error instanceof Error && error.name === "TimeoutError") {
+    if (isTimeoutError(error)) {
       console.error("Mempool balance fetch timed out:", error);
       return null;
     }
-    if (retries < MAX_RETRIES) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      return await getBTCBalanceFromMempool(address, retries + 1);
-    } else {
-      console.error("Mempool balance fetch error:", error);
-      return null;
+    // Retry non-timeout errors (429 / 5xx / network) only while there is still
+    // budget for the back-off AND another attempt.
+    if (
+      retries < MAX_RETRIES &&
+      deadlineAt - Date.now() > RETRY_DELAY_MS
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      return await getBTCBalanceFromMempool(address, retries + 1, deadlineAt);
     }
+    console.error("Mempool balance fetch error:", error);
+    return null;
   }
 };

--- a/lib/utils/data/processing/balanceUtils.ts
+++ b/lib/utils/data/processing/balanceUtils.ts
@@ -7,21 +7,51 @@ import {
 import { BLOCKCYPHER_API_BASE_URL } from "$constants";
 import { formatSatoshisToBTC, formatUSDValue } from "$lib/utils/formatUtils.ts";
 import {
-  fetchWithTimeout,
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchJsonWithTimeout,
   getBTCBalanceFromMempool,
 } from "$lib/utils/mempool.ts";
 import { dbManager } from "$server/database/databaseManager.ts";
 
+/**
+ * Default total budget for the BTC-balance provider chain (all providers,
+ * retries and body reads combined). Before this the chain had only per-fetch
+ * deadlines, so the worst case was the SUM of every attempt: two providers
+ * x 5s, plus the mempool retry loop on non-timeout errors (4 x 5s + 3 x 1s
+ * back-off) — 10-23s measured on the aggregate balance endpoint (#1198).
+ */
+export const DEFAULT_BTC_BALANCE_TIMEOUT_MS = DEFAULT_FETCH_TIMEOUT_MS;
+
+/**
+ * Hard ceiling applied by the aggregate `/api/v2/balance/{address}` handler
+ * to its BTC leg. The stamps + SRC-20 legs answer in ~0.3-0.4s, so this keeps
+ * the whole response comfortably under the 5s regression threshold even when
+ * every BTC provider is unresponsive.
+ */
+export const BTC_BALANCE_LEG_CEILING_MS = 3000;
+
+/**
+ * The provider chain is handed `ceiling - grace` so that, when it honours its
+ * own deadline, it reports `unavailable` (providers failed within budget)
+ * rather than tripping the outer ceiling (`timeout`: something outside the
+ * chain's control — e.g. the cache layer — stalled).
+ */
+const BTC_BALANCE_CEILING_GRACE_MS = 200;
+
 async function getBTCBalanceFromBlockCypher(
   address: string,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<BTCBalance | null> {
   try {
-    const response = await fetchWithTimeout(
+    const result = await fetchJsonWithTimeout<
+      BlockCypherAddressBalanceResponse
+    >(
       `${BLOCKCYPHER_API_BASE_URL}/v1/btc/main/addrs/${address}/balance`,
+      timeoutMs,
     );
-    if (!response.ok) return null;
+    if (!result.ok || !result.data) return null;
 
-    const data = await response.json() as BlockCypherAddressBalanceResponse;
+    const data = result.data;
     const confirmed = data.balance || 0;
     const unconfirmed = data.unconfirmed_balance || 0;
 
@@ -41,26 +71,30 @@ async function getBTCBalanceFromBlockCypher(
 // Cached wrapper for getBTCBalanceFromMempool with Redis caching
 async function getCachedBTCBalanceFromMempool(
   address: string,
+  timeoutMs: number,
 ): Promise<BTCBalance | null> {
   const cacheKey = `btc_balance:mempool:${address}`;
   const cacheDuration = 60; // 60 seconds TTL - balances can change frequently
+  const fetchFresh = () =>
+    getBTCBalanceFromMempool(address, 0, Date.now() + timeoutMs);
 
   try {
     return await dbManager.handleCache(
       cacheKey,
-      () => getBTCBalanceFromMempool(address),
+      fetchFresh,
       cacheDuration,
     ) as BTCBalance | null;
   } catch (error) {
     console.error("Cached balance fetch error:", error);
     // Fallback to direct call if caching fails
-    return getBTCBalanceFromMempool(address);
+    return fetchFresh();
   }
 }
 
 // Cached wrapper for getBTCBalanceFromBlockCypher with Redis caching
 async function getCachedBTCBalanceFromBlockCypher(
   address: string,
+  timeoutMs: number,
 ): Promise<BTCBalance | null> {
   const cacheKey = `btc_balance:blockcypher:${address}`;
   const cacheDuration = 60; // 60 seconds TTL
@@ -68,13 +102,13 @@ async function getCachedBTCBalanceFromBlockCypher(
   try {
     return await dbManager.handleCache(
       cacheKey,
-      () => getBTCBalanceFromBlockCypher(address),
+      () => getBTCBalanceFromBlockCypher(address, timeoutMs),
       cacheDuration,
     ) as BTCBalance | null;
   } catch (error) {
     console.error("Cached BlockCypher balance fetch error:", error);
     // Fallback to direct call if caching fails
-    return getBTCBalanceFromBlockCypher(address);
+    return getBTCBalanceFromBlockCypher(address, timeoutMs);
   }
 }
 
@@ -83,22 +117,39 @@ export async function getBTCBalanceInfo(
   options: BTCBalanceInfoOptions = {},
 ): Promise<BTCBalanceInfo | null> {
   try {
-    // Use cached versions of balance providers
+    const totalBudgetMs = options.timeoutMs ?? DEFAULT_BTC_BALANCE_TIMEOUT_MS;
+    const deadlineAt = Date.now() + totalBudgetMs;
+
+    // Use cached versions of balance providers. They run sequentially against
+    // ONE shared deadline: each provider gets an equal share of whatever budget
+    // is left, so a hung first provider cannot starve the fallback, and a
+    // provider that fails fast hands its unused share to the next one.
     const providers = [
       {
         name: "Mempool (cached)",
-        fn: () => getCachedBTCBalanceFromMempool(address),
+        fn: (budgetMs: number) =>
+          getCachedBTCBalanceFromMempool(address, budgetMs),
       },
       {
         name: "BlockCypher (cached)",
-        fn: () => getCachedBTCBalanceFromBlockCypher(address),
+        fn: (budgetMs: number) =>
+          getCachedBTCBalanceFromBlockCypher(address, budgetMs),
       },
     ];
     let balance = null;
 
-    for (const provider of providers) {
+    for (const [index, provider] of providers.entries()) {
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs <= 0) {
+        console.error(
+          `BTC balance budget (${totalBudgetMs}ms) exhausted before ${provider.name}`,
+        );
+        break;
+      }
+      const providersLeft = providers.length - index;
+      const budgetMs = Math.max(1, Math.floor(remainingMs / providersLeft));
       try {
-        const result = await provider.fn();
+        const result = await provider.fn(budgetMs);
         if (result) {
           balance = result;
           console.log(`Using balance data from ${provider.name}`);
@@ -172,4 +223,70 @@ export async function getBTCBalanceInfo(
     console.error("Error in getBTCBalanceInfo:", error);
     return null;
   }
+}
+
+export type BTCBalanceLegStatus = "ok" | "unavailable" | "timeout";
+
+export interface BTCBalanceLegResult {
+  /**
+   * `ok`          — a provider answered inside the budget.
+   * `unavailable` — every provider failed / timed out inside the budget.
+   * `timeout`     — the ceiling fired before the chain returned at all
+   *                 (a stall outside the chain's own deadline, e.g. cache).
+   */
+  status: BTCBalanceLegStatus;
+  info: BTCBalanceInfo | null;
+}
+
+/**
+ * `getBTCBalanceInfo` with a hard wall-clock ceiling. Always resolves — never
+ * rejects — within `ceilingMs`, so an aggregate endpoint can render its other
+ * legs with the `btc` block degraded instead of stalling or 5xx-ing because
+ * a third-party provider is slow. The underlying chain is handed a slightly
+ * shorter budget so it normally reports `unavailable` on its own; `timeout`
+ * only fires if something the chain does not bound (e.g. Redis) stalls. On
+ * `timeout` the in-flight chain is not cancelled: if it eventually succeeds
+ * it still warms the provider cache for the next request.
+ */
+export function getBTCBalanceInfoBounded(
+  address: string,
+  ceilingMs: number = BTC_BALANCE_LEG_CEILING_MS,
+  options: BTCBalanceInfoOptions = {},
+): Promise<BTCBalanceLegResult> {
+  const chainBudgetMs = Math.max(
+    1,
+    Math.min(
+      ceilingMs - BTC_BALANCE_CEILING_GRACE_MS,
+      options.timeoutMs ?? Number.POSITIVE_INFINITY,
+    ),
+  );
+
+  let timeoutId: number | undefined;
+  const ceiling = new Promise<BTCBalanceLegResult>((resolve) => {
+    timeoutId = setTimeout(() => {
+      console.error(
+        `BTC balance leg exceeded ${ceilingMs}ms ceiling for ${address}; responding with degraded btc block`,
+      );
+      resolve({ status: "timeout", info: null });
+    }, ceilingMs);
+  });
+
+  const chain = getBTCBalanceInfo(address, {
+    ...options,
+    timeoutMs: chainBudgetMs,
+  })
+    .then((info): BTCBalanceLegResult => ({
+      status: info ? "ok" : "unavailable",
+      info,
+    }))
+    // getBTCBalanceInfo already swallows errors; this is belt-and-braces so a
+    // provider failure can never surface as a 5xx from the aggregate route.
+    .catch((error): BTCBalanceLegResult => {
+      console.error("BTC balance leg failed:", error);
+      return { status: "unavailable", info: null };
+    });
+
+  return Promise.race([chain, ceiling]).finally(() => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  });
 }

--- a/routes/api/v2/balance/[address].ts
+++ b/routes/api/v2/balance/[address].ts
@@ -1,7 +1,10 @@
 import { Handlers } from "$fresh/server.ts";
 import type { AddressHandlerContext } from "$types/api.d.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
-import { getBTCBalanceInfo } from "$lib/utils/data/processing/balanceUtils.ts";
+import {
+  BTC_BALANCE_LEG_CEILING_MS,
+  getBTCBalanceInfoBounded,
+} from "$lib/utils/data/processing/balanceUtils.ts";
 import { getPaginationParams } from "$lib/utils/data/pagination/paginationUtils.ts";
 import { isValidBitcoinAddress } from "$lib/utils/typeGuards.ts";
 import { Src20Controller } from "$server/controller/src20Controller.ts";
@@ -52,8 +55,14 @@ export const handler: Handlers<AddressHandlerContext> = {
         page = DEFAULT_PAGINATION.page,
       } = pagination;
 
-      // Call controllers directly instead of making HTTP requests to avoid DNS issues
-      const [stamps, src20, btcInfo] = await Promise.all([
+      // Call controllers directly instead of making HTTP requests to avoid DNS issues.
+      //
+      // The BTC leg talks to third-party providers (mempool.space / BlockCypher)
+      // and is the only leg that can be slow; it is hard-capped so that a slow
+      // or rate-limiting provider degrades the `btc` block instead of stalling
+      // the stamps + SRC-20 data behind it (#1198). `btcLeg.status` is surfaced
+      // via the `X-BTC-Balance-Status` header; the response schema is unchanged.
+      const [stamps, src20, btcLeg] = await Promise.all([
         StampController.getStampBalancesByAddress(address, limit, page),
         Src20Controller.handleSrc20BalanceRequest({
           address,
@@ -61,8 +70,9 @@ export const handler: Handlers<AddressHandlerContext> = {
           page,
           includePagination: true,
         }),
-        getBTCBalanceInfo(address),
+        getBTCBalanceInfoBounded(address, BTC_BALANCE_LEG_CEILING_MS),
       ]);
+      const btcInfo = btcLeg.info;
 
       // NOTE: deliberately NO 404 for "valid address, zero holdings".
       //
@@ -114,6 +124,8 @@ export const handler: Handlers<AddressHandlerContext> = {
             "/api/v2/stamps/balance/[address], /api/v2/src20/balance/[address]",
           "X-Info":
             "Consider using dedicated endpoints for better performance and pagination control",
+          // ok | unavailable | timeout — when not "ok" the btc block is zeros.
+          "X-BTC-Balance-Status": btcLeg.status,
         },
       });
     } catch (error) {

--- a/tests/unit/routes/balanceAddressHandler.test.ts
+++ b/tests/unit/routes/balanceAddressHandler.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Handler-level regression test for GET /api/v2/balance/{address} (#1198,
+ * task 1217): the BTC leg is hard-capped at BTC_BALANCE_LEG_CEILING_MS so a
+ * slow third-party provider degrades the `btc` block (zeros + an
+ * `X-BTC-Balance-Status` header) instead of stalling the stamps + SRC-20
+ * data or producing a 5xx. The response schema is unchanged.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { handler } from "$routes/api/v2/balance/[address].ts";
+import { BTC_BALANCE_LEG_CEILING_MS } from "$lib/utils/data/processing/balanceUtils.ts";
+import { StampController } from "$server/controller/stampController.ts";
+import { Src20Controller } from "$server/controller/src20Controller.ts";
+
+/* ===== fixtures ===== */
+
+const STAMP_ROW = { cpid: "A1234567890123456789", quantity: 1 };
+const SRC20_ROW = { tick: "KEVIN", amt: "1000" };
+
+const STAMPS_RESULT = {
+  page: 1,
+  limit: 50,
+  totalPages: 1,
+  total: 1,
+  last_block: 900000,
+  data: [STAMP_ROW],
+};
+
+const SRC20_RESULT = {
+  page: 1,
+  limit: 50,
+  totalPages: 1,
+  total: 1,
+  last_block: 900001,
+  data: [SRC20_ROW],
+};
+
+function stubControllers() {
+  const stamps = stub(
+    StampController,
+    "getStampBalancesByAddress",
+    () =>
+      Promise.resolve(
+        STAMPS_RESULT as unknown as Awaited<
+          ReturnType<typeof StampController.getStampBalancesByAddress>
+        >,
+      ),
+  );
+  const src20 = stub(
+    Src20Controller,
+    "handleSrc20BalanceRequest",
+    () =>
+      Promise.resolve(
+        SRC20_RESULT as unknown as Awaited<
+          ReturnType<typeof Src20Controller.handleSrc20BalanceRequest>
+        >,
+      ),
+  );
+  return {
+    restore() {
+      stamps.restore();
+      src20.restore();
+    },
+  };
+}
+
+async function callHandler(address: string, query = "") {
+  const req = new Request(`http://localhost/api/v2/balance/${address}${query}`);
+  const ctx = { params: { address } } as unknown as Parameters<
+    NonNullable<typeof handler.GET>
+  >[1];
+  const started = Date.now();
+  const res = await handler.GET!(req, ctx);
+  const elapsed = Date.now() - started;
+  const body = await res.json();
+  return { res, body, elapsed };
+}
+
+// Distinct addresses per test: provider results are cached per address for 60s.
+const ADDR_SLOW = "bc1qzxszplp8v7w0jc89dlrqyct9staqlhwxzy7lkq";
+const ADDR_FAILING = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const ADDR_NORMAL = "bc1q20d2cdvy2x83h3ssrz5lgryy4c9wqxsgc749ej";
+
+const MEMPOOL_OK_BODY = {
+  address: ADDR_NORMAL,
+  chain_stats: {
+    funded_txo_count: 959,
+    funded_txo_sum: 13272991,
+    spent_txo_count: 944,
+    spent_txo_sum: 13257661,
+    tx_count: 981,
+  },
+  mempool_stats: {
+    funded_txo_count: 0,
+    funded_txo_sum: 0,
+    spent_txo_count: 0,
+    spent_txo_sum: 0,
+    tx_count: 0,
+  },
+};
+
+/* ===== (a) slow BTC leg does not delay the response beyond the ceiling ===== */
+
+Deno.test("balance/[address]: a BTC provider that never answers yields a degraded btc block within the ceiling", async () => {
+  const controllers = stubControllers();
+  // Worst case: upstream hangs AND ignores the abort signal.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => new Promise<Response>(() => {}),
+  );
+  try {
+    const { res, body, elapsed } = await callHandler(ADDR_SLOW);
+
+    assertEquals(res.status, 200); // never a 5xx for a slow third party
+    assert(
+      elapsed < BTC_BALANCE_LEG_CEILING_MS + 1000,
+      `expected < ${BTC_BALANCE_LEG_CEILING_MS + 1000}ms, took ${elapsed}ms`,
+    );
+    assertEquals(res.headers.get("X-BTC-Balance-Status"), "timeout");
+
+    // Stamps + SRC-20 data are served in full ...
+    assertEquals(body.data.stamps, [STAMP_ROW]);
+    assertEquals(body.data.src20, [SRC20_ROW]);
+    assertEquals(body.total, 2);
+    assertEquals(body.last_block, 900001);
+    // ... and the btc block keeps its shape, degraded to zeros.
+    assertEquals(body.btc, {
+      address: ADDR_SLOW,
+      balance: 0,
+      txCount: 0,
+      unconfirmedBalance: 0,
+      unconfirmedTxCount: 0,
+    });
+    // Existing informational headers are untouched.
+    assert(
+      res.headers.get("X-Preferred-Endpoints")?.includes(
+        "/api/v2/stamps/balance",
+      ),
+    );
+  } finally {
+    fetchStub.restore();
+    controllers.restore();
+  }
+});
+
+Deno.test("balance/[address]: providers answering 429 are retried only within budget and degrade to 'unavailable'", async () => {
+  const controllers = stubControllers();
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(new Response("rate limited", { status: 429 })),
+  );
+  try {
+    const { res, body, elapsed } = await callHandler(ADDR_FAILING);
+
+    assertEquals(res.status, 200);
+    assert(
+      elapsed < BTC_BALANCE_LEG_CEILING_MS,
+      `expected < ${BTC_BALANCE_LEG_CEILING_MS}ms, took ${elapsed}ms`,
+    );
+    assertEquals(res.headers.get("X-BTC-Balance-Status"), "unavailable");
+    // Pre-fix this path was 4 mempool attempts + 3 x 1s sleeps + BlockCypher.
+    assert(
+      fetchStub.calls.length <= 3,
+      `expected <= 3 provider calls, saw ${fetchStub.calls.length}`,
+    );
+    assertEquals(body.btc.balance, 0);
+    assertEquals(body.data.stamps, [STAMP_ROW]);
+  } finally {
+    fetchStub.restore();
+    controllers.restore();
+  }
+});
+
+/* ===== (b) normal path is unchanged ===== */
+
+Deno.test("balance/[address]: normal path returns the live btc balance with status 'ok'", async () => {
+  const controllers = stubControllers();
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(Response.json(MEMPOOL_OK_BODY)),
+  );
+  try {
+    const { res, body, elapsed } = await callHandler(
+      ADDR_NORMAL,
+      "?limit=50&page=1",
+    );
+
+    assertEquals(res.status, 200);
+    assert(elapsed < 1000, `expected < 1000ms, took ${elapsed}ms`);
+    assertEquals(res.headers.get("X-BTC-Balance-Status"), "ok");
+    assertEquals(fetchStub.calls.length, 1);
+
+    assertEquals(body.page, 1);
+    assertEquals(body.limit, 50);
+    assertEquals(body.total, 2);
+    assertEquals(body.totalPages, 1);
+    assertEquals(body.last_block, 900001);
+    assertEquals(body.btc, {
+      address: ADDR_NORMAL,
+      balance: 0.0001533,
+      txCount: 981,
+      unconfirmedBalance: 0,
+      unconfirmedTxCount: 0,
+    });
+    assertEquals(body.data.stamps, [STAMP_ROW]);
+    assertEquals(body.data.src20, [SRC20_ROW]);
+  } finally {
+    fetchStub.restore();
+    controllers.restore();
+  }
+});

--- a/tests/unit/utils/btcBalanceLegCeiling.test.ts
+++ b/tests/unit/utils/btcBalanceLegCeiling.test.ts
@@ -1,0 +1,296 @@
+import { assert, assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import {
+  fetchJsonWithTimeout,
+  getBTCBalanceFromMempool,
+} from "$lib/utils/mempool.ts";
+import {
+  BTC_BALANCE_LEG_CEILING_MS,
+  getBTCBalanceInfo,
+  getBTCBalanceInfoBounded,
+} from "$lib/utils/data/processing/balanceUtils.ts";
+
+// Regression coverage for #1198 / task 1217: the aggregate
+// /api/v2/balance/{address} endpoint still took 10-23s on a cold hit AFTER
+// #1206 bounded each individual provider fetch, because nothing bounded the
+// BTC leg as a whole: two sequential 5s deadlines (10s), plus the mempool
+// retry loop on non-timeout errors (4 x 5s + 3 x 1s back-off ~= 23s). The
+// provider chain now runs against ONE shared deadline, the body read is
+// covered by the same deadline, and the handler applies a hard ceiling.
+
+/* ===== fetch stubs ===== */
+
+/** Upstream that never answers but honours the abort signal (real Deno behaviour). */
+function hangUntilAbort() {
+  return stub(
+    globalThis,
+    "fetch",
+    (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      }),
+  );
+}
+
+/** Upstream that never answers AND ignores the abort signal (worst case). */
+function hangForever() {
+  return stub(
+    globalThis,
+    "fetch",
+    () => new Promise<Response>(() => {}),
+  );
+}
+
+const MEMPOOL_OK_BODY = {
+  address: "x",
+  chain_stats: {
+    funded_txo_count: 959,
+    funded_txo_sum: 13272991,
+    spent_txo_count: 944,
+    spent_txo_sum: 13257661,
+    tx_count: 981,
+  },
+  mempool_stats: {
+    funded_txo_count: 0,
+    funded_txo_sum: 0,
+    spent_txo_count: 0,
+    spent_txo_sum: 0,
+    tx_count: 0,
+  },
+};
+
+function mempoolOk() {
+  return stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(Response.json(MEMPOOL_OK_BODY)),
+  );
+}
+
+// Distinct addresses per test: successful provider results are cached in
+// dbManager's in-memory fallback cache for 60s within this test process.
+const ADDR_RETRY_SHORT = "bc1qzxszplp8v7w0jc89dlrqyct9staqlhwxzy7lkq";
+const ADDR_RETRY_LONG = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const ADDR_BUDGET_SPLIT = "bc1q20d2cdvy2x83h3ssrz5lgryy4c9wqxsgc749ej";
+const ADDR_FALLBACK = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const ADDR_NORMAL = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const ADDR_CEILING =
+  "bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9";
+const ADDR_UNAVAILABLE = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
+const ADDR_BOUNDED_OK =
+  "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
+
+/* ===== fetchJsonWithTimeout: the deadline covers the body read ===== */
+
+Deno.test("fetchJsonWithTimeout times out a body that never finishes streaming", async () => {
+  // Headers arrive immediately; the body stalls. fetchWithTimeout disarmed its
+  // timer once headers arrived, leaving response.json() unbounded — this helper
+  // keeps the abort armed until the body is parsed.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    (_input: string | URL | Request, init?: RequestInit) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          init?.signal?.addEventListener("abort", () => {
+            controller.error(new DOMException("aborted", "AbortError"));
+          });
+        },
+      });
+      return Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  );
+  try {
+    const started = Date.now();
+    let caught: unknown;
+    try {
+      await fetchJsonWithTimeout("https://example.com/", 50);
+    } catch (e) {
+      caught = e;
+    }
+    assert(caught instanceof Error, "expected an Error");
+    assertEquals(caught.name, "TimeoutError");
+    assert(Date.now() - started < 1000, "body read must be bounded");
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+/* ===== getBTCBalanceFromMempool: retries are bounded by the deadline ===== */
+
+Deno.test("getBTCBalanceFromMempool does not retry a 429 when the deadline leaves no room", async () => {
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(new Response("slow down", { status: 429 })),
+  );
+  try {
+    const started = Date.now();
+    const result = await getBTCBalanceFromMempool(
+      ADDR_RETRY_SHORT,
+      0,
+      Date.now() + 500, // < 1s retry back-off: no retry may be attempted
+    );
+    assertEquals(result, null);
+    assertEquals(fetchStub.calls.length, 1);
+    assert(Date.now() - started < 500, "must give up without sleeping");
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceFromMempool stops retrying once the deadline is spent", async () => {
+  // Before the fix a non-timeout error retried MAX_RETRIES (3) times with a
+  // 1s back-off regardless of any deadline: 4 attempts, >= 3s.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(new Response("upstream error", { status: 503 })),
+  );
+  try {
+    const started = Date.now();
+    const result = await getBTCBalanceFromMempool(
+      ADDR_RETRY_LONG,
+      0,
+      Date.now() + 1500,
+    );
+    const elapsed = Date.now() - started;
+    assertEquals(result, null);
+    assertEquals(fetchStub.calls.length, 2); // one retry fits, a second does not
+    assert(elapsed < 1500, `expected < 1500ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+/* ===== getBTCBalanceInfo: one shared budget across providers ===== */
+
+Deno.test("getBTCBalanceInfo bounds the WHOLE chain and still gives the fallback its share", async () => {
+  const fetchStub = hangUntilAbort();
+  try {
+    const started = Date.now();
+    const info = await getBTCBalanceInfo(ADDR_BUDGET_SPLIT, { timeoutMs: 400 });
+    const elapsed = Date.now() - started;
+    assertEquals(info, null);
+    // Both providers were tried (mempool did not starve BlockCypher) ...
+    assertEquals(fetchStub.calls.length, 2);
+    // ... and the total stayed inside the budget (was 2 x 5s before).
+    assert(elapsed < 1000, `expected < 1000ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfo hands a fast-failing provider's unused budget to the fallback", async () => {
+  let calls = 0;
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    (input: string | URL | Request) => {
+      calls++;
+      const url = String(input);
+      if (url.includes("blockcypher")) {
+        return Promise.resolve(
+          Response.json({
+            address: ADDR_FALLBACK,
+            balance: 15330,
+            unconfirmed_balance: 0,
+            n_tx: 981,
+            unconfirmed_n_tx: 0,
+          }),
+        );
+      }
+      return Promise.resolve(new Response("rate limited", { status: 429 }));
+    },
+  );
+  try {
+    const started = Date.now();
+    const info = await getBTCBalanceInfo(ADDR_FALLBACK, { timeoutMs: 600 });
+    const elapsed = Date.now() - started;
+    assert(info !== null, "BlockCypher fallback should have answered");
+    assertEquals(info.balance, 0.0001533);
+    assertEquals(info.txCount, 981);
+    assertEquals(calls, 2); // mempool once (no retry fits in its 300ms share), then BlockCypher
+    assert(elapsed < 600, `expected < 600ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfo normal path is unchanged: first provider answers, one fetch", async () => {
+  const fetchStub = mempoolOk();
+  try {
+    const info = await getBTCBalanceInfo(ADDR_NORMAL);
+    assert(info !== null);
+    assertEquals(info.address, ADDR_NORMAL);
+    assertEquals(info.balance, 0.0001533); // 15330 sats
+    assertEquals(info.txCount, 981);
+    assertEquals(info.unconfirmedBalance, 0);
+    assertEquals(info.unconfirmedTxCount, 0);
+    assertEquals(fetchStub.calls.length, 1);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+/* ===== getBTCBalanceInfoBounded: the handler-level ceiling ===== */
+
+Deno.test("BTC_BALANCE_LEG_CEILING_MS keeps the aggregate endpoint under the 5s regression threshold", () => {
+  assert(BTC_BALANCE_LEG_CEILING_MS > 0);
+  assert(BTC_BALANCE_LEG_CEILING_MS <= 3000);
+});
+
+Deno.test("getBTCBalanceInfoBounded resolves 'timeout' when the chain never returns", async () => {
+  // The upstream ignores the abort signal, so the chain can never finish on
+  // its own; only the outer ceiling can resolve this. The ceiling must leave
+  // the chain a real budget (ceiling - 200ms grace) — with a near-zero budget
+  // the chain would legitimately give up as 'unavailable' before it fires.
+  const fetchStub = hangForever();
+  try {
+    const started = Date.now();
+    const leg = await getBTCBalanceInfoBounded(ADDR_CEILING, 500);
+    const elapsed = Date.now() - started;
+    assertEquals(leg.status, "timeout");
+    assertEquals(leg.info, null);
+    assert(elapsed >= 450, `ceiling fired early: ${elapsed}ms`);
+    assert(elapsed < 1500, `expected < 1500ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfoBounded resolves 'unavailable' when providers fail inside the budget", async () => {
+  const fetchStub = hangUntilAbort();
+  try {
+    const started = Date.now();
+    const leg = await getBTCBalanceInfoBounded(ADDR_UNAVAILABLE, 2000, {
+      timeoutMs: 300,
+    });
+    const elapsed = Date.now() - started;
+    assertEquals(leg.status, "unavailable");
+    assertEquals(leg.info, null);
+    assert(elapsed < 2000, `expected < 2000ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfoBounded resolves 'ok' with the balance on the normal path", async () => {
+  const fetchStub = mempoolOk();
+  try {
+    const leg = await getBTCBalanceInfoBounded(ADDR_BOUNDED_OK, 1000);
+    assertEquals(leg.status, "ok");
+    assert(leg.info !== null);
+    assertEquals(leg.info.balance, 0.0001533);
+    assertEquals(leg.info.txCount, 981);
+  } finally {
+    fetchStub.restore();
+  }
+});


### PR DESCRIPTION
## Problem

`GET /api/v2/balance/{address}` still took **10–23 s** on a cold hit for large wallets after #1206 (23.3 s measured today for `bc1qzxszplp8v7w0jc89dlrqyct9staqlhwxzy7lkq`; 0.2 s warm), while `/api/v2/stamps/balance/{address}` and `/api/v2/src20/balance/{address}` answer in ~0.3 s for the same address. The daily regression job flags anything > 5 s as critical. Lineage: #1198 → #1206 → TaskMaster `1217@stampchain-io`.

## Root cause (with evidence)

The slow leg is `getBTCBalanceInfo()` (`lib/utils/data/processing/balanceUtils.ts`). Both public providers answer in ~0.3 s from a clean network, and Deno 2.6.9 (the Dockerfile image) does map the abort to `TimeoutError` correctly — so #1206's per-fetch timeout works as written. What it did **not** do is bound the leg as a whole:

1. **Sequential providers, independent deadlines** — mempool.space then BlockCypher, each with its own 5 s `DEFAULT_FETCH_TIMEOUT_MS` (`balanceUtils.ts` provider loop): **10 s** worst case on pure timeouts.
2. **Retry loop still fires on non-timeout errors** — `getBTCBalanceFromMempool` (`lib/utils/bitcoin/network/mempool.ts`) only skipped retries for `TimeoutError`. A 429 / 5xx / network error still retried `MAX_RETRIES=3` times with a 1 s back-off, each attempt bounded at 5 s again: **4 × 5 s + 3 × 1 s ≈ 23 s**, then BlockCypher ~0.3 s = **23.3 s** — exactly the number measured today.
3. **Body read was unbounded** — `fetchWithTimeout` clears its timer in `finally` as soon as `fetch()` resolves (headers), so the `response.json()` issued afterwards had no deadline. Verified against the real runtime with a stalled-body server: after `clearTimeout` the read hangs indefinitely; keeping the signal armed rejects the body read with `AbortError`.
4. (Secondary) `dbManager.handleCache` treats a `null` result as a miss, so a failing cold hit is never negatively cached and every request re-pays the full chain until a provider succeeds.

## Fix

**Provider chain (root cause):**
- `mempool.ts`: `fetchJsonWithTimeout()` keeps the abort armed through the body read. `getBTCBalanceFromMempool(address, retries, deadlineAt)` runs every attempt, back-off and body read against **one epoch deadline** and only retries while budget remains. `fetchWithTimeout` is unchanged for its other callers.
- `balanceUtils.ts`: `getBTCBalanceInfo()` runs the chain against a single total budget (`options.timeoutMs`, default 5 s). Each provider gets an equal share of the *remaining* budget, so a hung first provider cannot starve the BlockCypher fallback and a fast-failing one hands its unused share on. Worst case = the budget, not the sum of every attempt.

**Handler ceiling (structural guarantee):**
- `getBTCBalanceInfoBounded()` races the chain against a hard wall-clock ceiling (`BTC_BALANCE_LEG_CEILING_MS = 3000`) and always resolves `{ status: "ok" | "unavailable" | "timeout", info }` — never rejects, so a slow third party can never produce a 5xx. The chain is handed `ceiling − 200 ms` so it normally reports `unavailable` on its own; `timeout` only fires for stalls outside the chain's control (e.g. Redis). An in-flight chain is not cancelled on `timeout`, so a late success still warms the cache.
- `routes/api/v2/balance/[address].ts`: uses the bounded call. Degraded leg → `btc` block keeps its shape with zeros (same `?? 0` fallback as before) plus `X-BTC-Balance-Status: ok|unavailable|timeout`. **Response schema unchanged.** Worst case ≈ 3.4 s (< 5 s threshold).

Other callers of `getBTCBalanceInfo` (wallet adapters) get the same total-budget behaviour with the 5 s default and no signature change.

## Tests

`tests/unit/utils/btcBalanceLegCeiling.test.ts`, `tests/unit/routes/balanceAddressHandler.test.ts`:
- body-read timeout; deadline-bounded retries (no retry when no room; stops once spent); shared budget across providers with fallback share; fast-fail hand-off to BlockCypher; ceiling → `timeout`; in-budget failure → `unavailable`; normal path → `ok` with one fetch.
- handler: never-answering provider → 200, full stamps/src20 data, zeroed `btc` block, `X-BTC-Balance-Status: timeout`, within the ceiling; 429-ing provider → `unavailable` within budget, ≤ 3 provider calls (was 4 + 3 s of sleeps + 1); normal path unchanged (`ok`, live balance, existing headers intact).

## Gates

```
deno fmt --check   → Checked 615 files
deno lint          → Checked 722 files
deno check <6 changed .ts files> → OK
deno task test:unit → ok | 1133 passed (2897 steps) | 0 failed | 7 ignored
```

## Remaining risk / follow-ups

- The specific production trigger (why mempool.space answers slowly / non-2xx from the ECS egress IP — rate limiting is the likely candidate) is inferred from the timing arithmetic, not observed directly; the fix bounds every path regardless. Watch `X-BTC-Balance-Status` in the regression job to confirm.
- No negative caching for `null` provider results (item 4) — a persistently failing provider costs up to the budget per cold request. Cheap follow-up: short negative TTL.
- Under the 3 s handler budget mempool.space gets 1.4 s before BlockCypher takes over; BlockCypher's unauthenticated rate limit is tight, so if mempool.space is degraded for long the `btc` block may report `unavailable` more often. Env-overridable `MEMPOOL_API_URL` (self-hosted) removes that dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
