### PR TITLE
Promote dev → main: balance-endpoint ceiling (#1246), ordinals owner checks (#1244), response helpers (#1243), schema docs (#1245), regression-issue dedup (#1242)

### DIFF
--- a/.github/workflows/daily-regression-tests.yml
+++ b/.github/workflows/daily-regression-tests.yml
@@ -272,95 +272,107 @@ jobs:
             echo "✅ All regression checks passed"
           fi
 
-      - name: Create GitHub issue for critical regressions
+      - name: Open or update the rolling regression issue
         if: steps.check-regressions.outputs.status == 'critical' && env.SEND_NOTIFICATIONS == 'true'
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // One rolling issue per regression episode: the first failing run
+            // opens it, every later failing run appends a comment, and the
+            // next passing run closes it (see the step below). Previously the
+            // lookup was keyed on today's date, so every failing day opened a
+            // brand-new issue (31 of them accumulated between July and
+            // September 2026).
             const criticalIssues = '${{ steps.check-regressions.outputs.critical_issues }}';
             const warningIssues = '${{ steps.check-regressions.outputs.warning_issues }}';
-            const timestamp = '${{ env.TIMESTAMP }}';
-            
-            // Check if there's already an open regression issue today
-            const today = new Date().toISOString().split('T')[0];
-            const { data: existingIssues } = await github.rest.issues.listForRepo({
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const now = new Date().toUTCString();
+            const labels = ['api-regression', 'automated', 'critical'];
+
+            const { data: openIssues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'regression,automated',
+              labels: 'api-regression,automated',
               sort: 'created',
               direction: 'desc',
-              per_page: 5
+              per_page: 5,
             });
-            
-            const todayIssue = existingIssues.find(issue => 
-              issue.title.includes(today) || 
-              new Date(issue.created_at).toDateString() === new Date().toDateString()
-            );
-            
-            if (todayIssue) {
-              // Update existing issue
-              const updateBody = `
-            ## Update: ${new Date().toUTCString()}
-            
-            **Status**: 🔴 Critical regressions still detected  
-            **Critical Issues**: ${criticalIssues}  
-            **Warning Issues**: ${warningIssues}  
-            **Run ID**: ${{ github.run_id }}  
-            
-            ### Actions Required
-            - [ ] Review regression analysis in [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            - [ ] Check unexpected API changes
-            - [ ] Verify endpoint availability
-            - [ ] Update expected changes configuration if changes are intentional
-            
-            ---
+            const rolling = openIssues.find((issue) => !issue.pull_request);
+
+            const details = `
+            **Run**: ${now}
+            **Critical issues**: ${criticalIssues}
+            **Warning issues**: ${warningIssues}
+            **Workflow run**: [${{ github.run_id }}](${runUrl})
+
+            Review \`expected-changes-validation.json\` in the run artifacts: \`schemaViolations\` lists responses that do not match \`schema.yml\`; entries with \`performanceIssue: "critical"\` exceeded the 5 s threshold.
             `;
-              
+
+            if (rolling) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: todayIssue.number,
-                body: updateBody
+                issue_number: rolling.number,
+                body: `## 🔴 Still failing\n${details}`,
               });
+              core.info(`Updated rolling regression issue #${rolling.number}`);
             } else {
-              // Create new issue
-              const issueBody = `
-            # 🚨 Daily Regression Test Failures - ${today}
-            
-            Critical API regressions detected during automated daily testing.
-            
-            ## Summary
-            - **Date**: ${new Date().toUTCString()}
-            - **Critical Issues**: ${criticalIssues}
-            - **Warning Issues**: ${warningIssues}
-            - **Workflow Run**: [View Details](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            
-            ## Investigation Required
-            - [ ] Review detailed regression analysis
-            - [ ] Check for unexpected API changes
-            - [ ] Verify production endpoint availability
-            - [ ] Determine if changes are intentional
-            - [ ] Update expected changes configuration if needed
-            
-            ## Next Steps
-            1. Download test artifacts from the workflow run
-            2. Review \`expected-changes-validation.json\` for details
-            3. Check HTML reports for specific failures
-            4. Update \`scripts/validate-expected-changes.cjs\` if changes are expected
-            
-            ---
-            *This issue was automatically created by the daily regression testing workflow.*
-            `;
-              
-              await github.rest.issues.create({
+              const { data: created } = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `🚨 API Regression Detected - ${today}`,
-                body: issueBody,
-                labels: ['regression', 'automated', 'critical']
+                title: '🚨 API regression detected by the daily regression run',
+                body: `# 🚨 Daily regression run is failing
+
+            Critical API regressions were detected against production. This issue stays open and collects one comment per failing run; it is closed automatically by the next passing run.
+
+            ## First failing run
+            ${details}
+
+            ## Investigation
+            - [ ] Download the run artifacts and read \`expected-changes-validation.json\`
+            - [ ] Decide whether each violation is a real regression, an intentional change (then update \`schema.yml\`), or validator noise (then fix \`scripts/validate-expected-changes.cjs\`)
+            - [ ] For performance-critical entries, check the endpoint's cold-hit latency against production directly
+
+            ---
+            *Opened automatically by the daily regression testing workflow.*
+            `,
+                labels,
               });
+              core.info(`Opened rolling regression issue #${created.number}`);
+            }
+
+      - name: Close the rolling regression issue on a passing run
+        if: steps.check-regressions.outputs.status == 'success' && env.SEND_NOTIFICATIONS == 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'api-regression,automated',
+              per_page: 20,
+            });
+            for (const issue of openIssues) {
+              if (issue.pull_request) continue;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `## ✅ Resolved\n\nThe daily regression run passed on ${new Date().toUTCString()} ([run ${{ github.run_id }}](${runUrl})). Closing automatically.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.info(`Closed regression issue #${issue.number}`);
             }
 
       - name: Upload comprehensive reports

--- a/client/wallet/wallet.ts
+++ b/client/wallet/wallet.ts
@@ -120,8 +120,8 @@ export const walletContext: WalletContext = {
   updateWallet,
   disconnect,
   getBasicStampInfo,
-  signMessage: async (message: string) => {
-    return await signMessage(walletContext.wallet, message);
+  signMessage: async (message: string, address?: string) => {
+    return await signMessage(walletContext.wallet, message, address);
   },
   signPSBT: async (
     wallet: Wallet,

--- a/client/wallet/walletHelper.ts
+++ b/client/wallet/walletHelper.ts
@@ -7,11 +7,18 @@ import { unisatProvider } from "$client/wallet/unisat.ts";
 import { wonderProvider } from "$client/wallet/wonder.ts";
 import { xverseProvider } from "$client/wallet/xverse.ts";
 import { logger } from "$lib/utils/logger.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import type { SignPSBTResult, Wallet } from "$types/index.d.ts";
 import type { PSBTInputToSign } from "$types/wallet.d.ts";
 
 interface WalletProvider {
-  signMessage: (message: string) => Promise<string>;
+  /**
+   * Sign `message`. `address` (optional) selects which of the wallet's own
+   * addresses signs; providers that expose a single address may ignore it —
+   * `signMessage()` below already guarantees it is one of the wallet's
+   * addresses before the provider is called.
+   */
+  signMessage: (message: string, address?: string) => Promise<string>;
   signPSBT: (
     psbtHex: string,
     inputsToSign: PSBTInputToSign[],
@@ -189,12 +196,30 @@ export const getWalletProvider = (
   }
 };
 
-export const signMessage = async (wallet: Wallet, message: string) => {
+/**
+ * Sign `message` with the connected wallet.
+ *
+ * @param address - Optional address that must produce the signature. Used when
+ *   an owner action targets a resource keyed by one of the wallet's secondary
+ *   addresses (e.g. the Xverse ordinals address). It MUST be an address the
+ *   wallet controls (see `walletOwnsAddress`); anything else is rejected here
+ *   so a provider is never asked to sign for a foreign address.
+ */
+export const signMessage = async (
+  wallet: Wallet,
+  message: string,
+  address?: string,
+) => {
   console.log("Signing message for wallet:", wallet.provider);
   console.log("Message to sign:", message);
   if (!wallet.provider) throw new Error("No wallet provider specified");
+  if (address !== undefined && !walletOwnsAddress(wallet, address)) {
+    throw new Error(
+      "Signing address is not controlled by the connected wallet",
+    );
+  }
   const provider = getWalletProvider(wallet.provider);
-  return await provider.signMessage(message);
+  return await provider.signMessage(message, address);
 };
 
 export const signPSBT = async (

--- a/client/wallet/xverse.ts
+++ b/client/wallet/xverse.ts
@@ -7,7 +7,7 @@
  * Capabilities:
  *   - Provider detection (checkXverse)
  *   - Wallet connection with payment (P2WPKH) and ordinals (P2TR) addresses (connectXverse)
- *   - Message signing via ECDSA (signMessage)
+ *   - Message signing via ECDSA, or BIP-322 for the ordinals address (signMessage)
  *   - PSBT signing with automatic hex/base64 conversion (signPSBT)
  *
  * PSBT format: stampchain.io uses hex internally; Xverse requires base64.
@@ -16,6 +16,10 @@
 
 import { walletContext } from "$client/wallet/wallet.ts";
 import { parseConnectionError } from "$client/wallet/walletHelper.ts";
+import {
+  resolveXverseSigningAddress,
+  xverseSigningProtocolFor,
+} from "$client/wallet/xverseSigning.ts";
 import { getBTCBalanceInfo } from "$lib/utils/data/processing/balanceUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
 import type { BaseToast } from "$lib/utils/ui/notifications/toastSignal.ts";
@@ -381,40 +385,51 @@ export const signPSBT = async (
 /**
  * Sign an arbitrary message with the connected Xverse wallet.
  *
- * Uses ECDSA signing via the Xverse BitcoinProvider.signMessage() API.
- * The wallet address is automatically retrieved from the walletContext signal.
+ * Signs with the payment address (ECDSA) by default. When `address` is the
+ * wallet's ordinals address the message is signed with that address using
+ * BIP-322 instead, so owner actions on resources keyed by the ordinals
+ * address can be verified against that address.
  *
  * Error codes:
  *   - USER_REJECTION (-32000 / 4001): re-thrown as-is for caller to handle
  *   - INVALID_PARAMS (-32602): re-thrown as-is for caller to handle
  *
  * @param message - Arbitrary UTF-8 message string to sign
+ * @param address - Optional address that must sign; must be one of the
+ *   connected wallet's addresses
  * @returns Base64-encoded signature string
  * @throws {Error} "Xverse wallet not installed" if extension is absent
  * @throws {Error} "Wallet not connected" if no address is in walletContext
+ * @throws {Error} if `address` is not controlled by the connected wallet
  * @throws {Error} "Unexpected response format from Xverse signMessage" for unknown responses
  */
-export const signMessage = async (message: string): Promise<string> => {
+export const signMessage = async (
+  message: string,
+  address?: string,
+): Promise<string> => {
   const provider = getXverseProvider();
   if (!provider) {
     throw new Error("Xverse wallet not installed");
   }
 
-  const walletAddress = walletContext.wallet.address;
-  if (!walletAddress) {
+  const wallet = walletContext.wallet;
+  if (!wallet.address) {
     throw new Error("Wallet not connected");
   }
+
+  const signingAddress = resolveXverseSigningAddress(wallet, address);
+  const protocol = xverseSigningProtocolFor(signingAddress);
 
   try {
     logger.debug("ui", {
       message: "Signing message with Xverse",
-      data: { messageLength: message.length },
+      data: { messageLength: message.length, protocol },
     });
 
     const response = await provider.signMessage({
-      address: walletAddress,
+      address: signingAddress,
       message,
-      protocol: "ECDSA",
+      protocol,
     });
 
     if (typeof response === "string") {
@@ -449,7 +464,7 @@ export const signMessage = async (message: string): Promise<string> => {
  * functions directly.
  *
  * Compatible with WalletProvider interface:
- *   - signMessage(message: string): Promise<string>
+ *   - signMessage(message: string, address?: string): Promise<string>
  *   - signPSBT(psbtHex, inputsToSign, enableRBF?, sighashTypes?, autoBroadcast?): Promise<SignPSBTResult>
  *   - broadcastRawTX?(rawTx: string): Promise<string>  [not supported]
  *   - broadcastPSBT?(psbtHex: string): Promise<string>  [not supported]

--- a/client/wallet/xverseSigning.ts
+++ b/client/wallet/xverseSigning.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helpers for choosing how the Xverse wallet signs a message.
+ *
+ * Kept free of the `xverse.ts` <-> `walletHelper.ts` <-> `wallet.ts` import
+ * cycle so they can be imported (and unit-tested) in isolation.
+ */
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
+import type { Wallet } from "$types/wallet.d.ts";
+
+export type XverseSigningProtocol = "ECDSA" | "BIP322";
+
+/**
+ * Pick which of the connected Xverse addresses signs a message.
+ *
+ * Defaults to the payment address. A caller may request the ordinals address
+ * (or, redundantly, the payment address) — anything the wallet does not
+ * control is rejected so we never ask Xverse to sign for a foreign address.
+ */
+export const resolveXverseSigningAddress = (
+  wallet: Pick<Wallet, "address" | "ordinalsAddress" | "accounts">,
+  address?: string,
+): string => {
+  if (address === undefined) return wallet.address;
+  if (!walletOwnsAddress(wallet, address)) {
+    throw new Error(
+      "Signing address is not controlled by the connected Xverse wallet",
+    );
+  }
+  return address;
+};
+
+/**
+ * Xverse only supports ECDSA message signing for its payment address
+ * (P2WPKH / P2SH). Taproot (P2TR, `bc1p…`) addresses must sign with BIP-322,
+ * which the server-side verifier (`verifySignature` in cryptoUtils) accepts.
+ */
+export const xverseSigningProtocolFor = (
+  signingAddress: string,
+): XverseSigningProtocol => {
+  return /^(bc|tb|bcrt)1p/i.test(signingAddress) ? "BIP322" : "ECDSA";
+};

--- a/islands/header/WalletHeader.tsx
+++ b/islands/header/WalletHeader.tsx
@@ -15,6 +15,7 @@ import {
   formatBTCAmount,
 } from "$lib/utils/ui/formatting/formatUtils.ts";
 import { showToast } from "$lib/utils/ui/notifications/toastSignal.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import { tooltipIcon } from "$notification";
 import { subtitlePrimary, text, titlePrimary, valueSm } from "$text";
 import type { WalletHeaderProps } from "$types/ui.d.ts";
@@ -95,6 +96,7 @@ function WalletOverview({ walletData }: { walletData: WalletOverviewInfo }) {
   const handleEditClick = () => {
     openModal(
       <EditCreatorNameModal
+        address={walletData.address}
         currentName={walletData.creatorName || ""}
         onSuccess={(newName) => {
           setDisplayName(newName);
@@ -120,9 +122,10 @@ function WalletOverview({ walletData }: { walletData: WalletOverviewInfo }) {
     walletData.creatorName !== `${name}.btc`
   );
 
-  // Check if the connected wallet owns this profile
-  const isOwner = wallet?.address &&
-    wallet.address.toLowerCase() === walletData.address.toLowerCase();
+  // Check if the connected wallet owns this profile. Goes through the
+  // canonical helper so secondary addresses (e.g. the Xverse ordinals
+  // address) are recognised as well as the primary payment address.
+  const isOwner = walletOwnsAddress(wallet, walletData.address);
 
   /* ===== RENDER ===== */
   return (

--- a/islands/modal/EditCreatorNameModal.tsx
+++ b/islands/modal/EditCreatorNameModal.tsx
@@ -7,6 +7,7 @@ import { ModalBase } from "$layout";
 import { logger } from "$lib/utils/logger.ts";
 import { getCSRFToken } from "$lib/utils/security/clientSecurityUtils.ts";
 import { showToast } from "$lib/utils/ui/notifications/toastSignal.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import { labelSm } from "$text";
 import { useState } from "preact/hooks";
 
@@ -17,6 +18,12 @@ const CREATOR_NAME_PATTERN = /^[a-zA-Z0-9 .\-_']+$/;
 
 /* ===== TYPES ===== */
 export interface EditCreatorNameModalProps {
+  /**
+   * Address whose creator name is being edited (the profile being viewed).
+   * Must be one of the connected wallet's addresses — payment or ordinals —
+   * and is the address that signs the update and that the server verifies.
+   */
+  address: string;
   currentName?: string;
   onSuccess?: (newName: string) => void;
 }
@@ -52,6 +59,7 @@ export function validateCreatorName(
 
 /* ===== COMPONENT ===== */
 function EditCreatorNameModal({
+  address,
   currentName,
   onSuccess,
 }: EditCreatorNameModalProps) {
@@ -94,6 +102,16 @@ function EditCreatorNameModal({
       return;
     }
 
+    // Guard: the profile address must belong to the connected wallet
+    // (payment or ordinals address). Never sign/submit for a foreign address.
+    if (!walletOwnsAddress(wallet, address)) {
+      showToast(
+        "The connected wallet does not control this address",
+        "error",
+      );
+      return;
+    }
+
     // Client-side validation
     const validation = validateCreatorName(newName);
     if (!validation.valid) {
@@ -130,9 +148,12 @@ function EditCreatorNameModal({
         component: "EditCreatorNameModal",
       });
 
+      // Sign with the profile address itself, so the server-side check
+      // (signature must verify against the address being updated) holds for
+      // secondary addresses such as the Xverse ordinals address.
       let signature: string;
       try {
-        const rawSignature = await walletContext.signMessage(message);
+        const rawSignature = await walletContext.signMessage(message, address);
         console.log(
           "[EditCreatorName] signMessage returned:",
           typeof rawSignature,
@@ -169,7 +190,7 @@ function EditCreatorNameModal({
       // Step 3: POST to API
       logger.debug("ui", {
         message: "Submitting creator name update",
-        address: wallet.address,
+        address,
         newName: trimmedName,
         component: "EditCreatorNameModal",
       });
@@ -181,7 +202,7 @@ function EditCreatorNameModal({
           "X-CSRF-Token": csrfToken,
         },
         body: JSON.stringify({
-          address: wallet.address,
+          address,
           newName: trimmedName,
           signature,
           timestamp,

--- a/islands/table/UploadImageTable.tsx
+++ b/islands/table/UploadImageTable.tsx
@@ -6,6 +6,7 @@ import {
   formatDate,
 } from "$lib/utils/ui/formatting/formatUtils.ts";
 import { getSRC20ImageSrc } from "$lib/utils/ui/media/imageUtils.ts";
+import { walletOwnsAddress } from "$lib/utils/wallet/ownership.ts";
 import { textLg } from "$text";
 import type { WalletDataTypes } from "$types/base.d.ts";
 import type { SRC20Row } from "$types/src20.d.ts";
@@ -39,6 +40,11 @@ export const UploadImageTable = (props: SRC20BalanceTableProps) => {
   // PERFORMANCE OPTIMIZATION: Use wallet signal instead of polling localStorage
   // This eliminates the 1-second polling that was consuming CPU resources
   const wallet = walletSignal.value as WalletDataTypes;
+  // Tokens deployed by any of the connected wallet's addresses (payment or
+  // ordinals) — see lib/utils/wallet/ownership.ts.
+  const ownedRows = data.filter((row) =>
+    walletOwnsAddress(walletSignal.value, row.creator)
+  );
 
   /* ===== EVENT HANDLERS ===== */
   const handleCloseModal = () => {
@@ -80,7 +86,7 @@ export const UploadImageTable = (props: SRC20BalanceTableProps) => {
                 </tr>
               </thead>
               <tbody>
-                {data.filter((row) => row.creator === wallet.address).map(
+                {ownedRows.map(
                   // data.map(
                   (src20: SRC20Row) => {
                     const href = `/upload/${unicodeEscapeToEmoji(src20.tick)}`;

--- a/lib/types/ui.d.ts
+++ b/lib/types/ui.d.ts
@@ -4112,7 +4112,7 @@ export interface WalletContext {
   updateWallet: (wallet: Wallet) => void;
   getBasicStampInfo: (address: string) => Promise<any>;
   disconnect: () => void;
-  signMessage: (message: string) => Promise<any>;
+  signMessage: (message: string, address?: string) => Promise<any>;
   signPSBT: (
     wallet: Wallet,
     psbt: string,

--- a/lib/types/utils.d.ts
+++ b/lib/types/utils.d.ts
@@ -294,6 +294,12 @@ export interface BTCBalanceInfoOptions {
   minConfirmations?: number;
   address?: string;
   includeUSD?: boolean;
+  /**
+   * Total wall-clock budget (ms) for the whole BTC-balance provider chain —
+   * every provider, retry and body read combined. Defaults to
+   * `DEFAULT_BTC_BALANCE_TIMEOUT_MS` in balanceUtils.
+   */
+  timeoutMs?: number;
 }
 
 /**

--- a/lib/utils/api/responses/webResponseUtil.ts
+++ b/lib/utils/api/responses/webResponseUtil.ts
@@ -287,16 +287,52 @@ export class WebResponseUtil {
     });
   }
 
+  /**
+   * Re-emit an upstream response with a replaced body and optional header
+   * overrides. Headers are merged case-insensitively so an override such as
+   * `Vary` or `Cache-Control` replaces the upstream value regardless of key
+   * casing. Pass `immutableBinary: true` to keep `Vary` limited to
+   * `Accept-Encoding` (plus any caller-supplied values) so Cloudflare can
+   * cache the response at the edge.
+   */
   static modifiedResponse(
     content: string,
     originalResponse: Response,
     options: WebResponseOptions = {},
   ): Response {
+    const merged = new Headers(originalResponse.headers);
+    for (const [key, value] of Object.entries(options.headers || {})) {
+      merged.set(key, value);
+    }
     return new Response(content, {
-      status: originalResponse.status,
+      status: options.status ?? originalResponse.status,
       statusText: originalResponse.statusText,
+      headers: normalizeHeaders(
+        merged,
+        options.immutableBinary ? { immutableBinary: true } : {},
+      ),
+    });
+  }
+
+  /**
+   * XML document response (sitemaps, feeds). Mirrors `htmlResponse` but with
+   * an XML content type. Caller-supplied headers override the defaults, so
+   * pass explicit `Cache-Control` / CDN cache headers when the document must
+   * not inherit the 1-year immutable default from `getSecurityHeaders`.
+   */
+  static xmlResponse(
+    xmlContent: string,
+    options: WebResponseOptions = {},
+  ): Response {
+    return new Response(xmlContent, {
+      status: options.status || 200,
       headers: normalizeHeaders({
-        ...Object.fromEntries(originalResponse.headers.entries()),
+        ...getSecurityHeaders({
+          forceNoCache: options.forceNoCache ?? false,
+          context: "web",
+        }),
+        "Content-Type": "application/xml; charset=utf-8",
+        "X-API-Version": API_RESPONSE_VERSION,
         ...(options.headers || {}),
       }),
     });

--- a/lib/utils/bitcoin/network/mempool.ts
+++ b/lib/utils/bitcoin/network/mempool.ts
@@ -1,4 +1,5 @@
 const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
 import { MEMPOOL_API_BASE_URL } from "$constants";
 import type { BTCBalance, MempoolAddressResponse } from "$lib/types/index.d.ts";
 
@@ -6,6 +7,21 @@ import type { BTCBalance, MempoolAddressResponse } from "$lib/types/index.d.ts";
 // upstream (mempool.space / BlockCypher) blocks the caller indefinitely — this
 // is what hung the aggregate `/api/v2/balance/{address}` endpoint (#1198).
 export const DEFAULT_FETCH_TIMEOUT_MS = 5000;
+
+function makeTimeoutError(timeoutMs: number): Error {
+  const timeoutError = new Error(`Request timed out after ${timeoutMs}ms`);
+  timeoutError.name = "TimeoutError";
+  return timeoutError;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+/** `true` when `error` is the `TimeoutError` thrown by the helpers below. */
+export function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
 
 /**
  * `fetch` with an `AbortController` deadline so a slow/unresponsive upstream
@@ -22,11 +38,46 @@ export async function fetchWithTimeout(
   try {
     return await fetch(input, { ...init, signal: controller.signal });
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      const timeoutError = new Error(`Request timed out after ${timeoutMs}ms`);
-      timeoutError.name = "TimeoutError";
-      throw timeoutError;
+    if (isAbortError(error)) throw makeTimeoutError(timeoutMs);
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export interface JsonFetchResult<T> {
+  ok: boolean;
+  status: number;
+  /** Parsed body when `ok`; `null` for non-2xx responses. */
+  data: T | null;
+}
+
+/**
+ * Like `fetchWithTimeout`, but the deadline covers the *whole* exchange —
+ * headers AND body. `fetchWithTimeout` disarms its timer as soon as `fetch()`
+ * resolves (headers received), so a `response.json()` issued afterwards is
+ * unbounded again. Here the abort signal stays armed until the body has been
+ * parsed; aborting mid-read rejects the body stream, which is mapped to the
+ * same `TimeoutError`. Non-2xx responses are drained and returned with
+ * `data: null` so callers can decide whether to retry.
+ */
+export async function fetchJsonWithTimeout<T>(
+  input: string | URL,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+  init: RequestInit = {},
+): Promise<JsonFetchResult<T>> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(input, { ...init, signal: controller.signal });
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => {});
+      return { ok: false, status: response.status, data: null };
     }
+    const data = await response.json() as T;
+    return { ok: true, status: response.status, data };
+  } catch (error) {
+    if (isAbortError(error)) throw makeTimeoutError(timeoutMs);
     throw error;
   } finally {
     clearTimeout(timeoutId);
@@ -118,20 +169,37 @@ export const getTransactionInfo = async (
   }
 };
 
+/**
+ * Fetch the BTC balance of `address` from mempool.space.
+ *
+ * `deadlineAt` (epoch ms) bounds the WHOLE call — every attempt, every retry
+ * back-off, and the body read — so the worst case is `deadlineAt - now`, not
+ * `MAX_RETRIES x per-fetch timeout + back-offs`. Before this the per-fetch
+ * deadline added by #1206 still let a provider that answered 429/5xx (a
+ * non-timeout error) retry 4 x 5s + 3 x 1s ~= 23s, which is exactly what the
+ * aggregate `/api/v2/balance/{address}` endpoint was measured at (#1198).
+ */
 export const getBTCBalanceFromMempool = async (
   address: string,
   retries = 0,
+  deadlineAt: number = Date.now() + DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<BTCBalance | null> => {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) return null;
+
+  const endpoint = `${MEMPOOL_API_BASE_URL}/address/${address}`;
   try {
-    const endpoint = `${MEMPOOL_API_BASE_URL}/address/${address}`;
-    const response = await fetchWithTimeout(endpoint);
-    if (!response.ok) {
+    const result = await fetchJsonWithTimeout<MempoolAddressResponse>(
+      endpoint,
+      Math.min(remaining, DEFAULT_FETCH_TIMEOUT_MS),
+    );
+    if (!result.ok || !result.data) {
       throw new Error(
-        `Error: response for: ${endpoint} unsuccessful. Response: ${response.status}`,
+        `Error: response for: ${endpoint} unsuccessful. Response: ${result.status}`,
       );
     }
 
-    const data = await response.json() as MempoolAddressResponse;
+    const data = result.data;
     const confirmed = data.chain_stats.funded_txo_sum -
       data.chain_stats.spent_txo_sum;
     const unconfirmed = data.mempool_stats.funded_txo_sum -
@@ -148,16 +216,20 @@ export const getBTCBalanceFromMempool = async (
     // A timeout means the upstream is unresponsive; retrying just re-accumulates
     // the delay (MAX_RETRIES x timeout) — exactly what let this hang the aggregate
     // balance endpoint (#1198). Fail fast so the caller can fall through / degrade.
-    if (error instanceof Error && error.name === "TimeoutError") {
+    if (isTimeoutError(error)) {
       console.error("Mempool balance fetch timed out:", error);
       return null;
     }
-    if (retries < MAX_RETRIES) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      return await getBTCBalanceFromMempool(address, retries + 1);
-    } else {
-      console.error("Mempool balance fetch error:", error);
-      return null;
+    // Retry non-timeout errors (429 / 5xx / network) only while there is still
+    // budget for the back-off AND another attempt.
+    if (
+      retries < MAX_RETRIES &&
+      deadlineAt - Date.now() > RETRY_DELAY_MS
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      return await getBTCBalanceFromMempool(address, retries + 1, deadlineAt);
     }
+    console.error("Mempool balance fetch error:", error);
+    return null;
   }
 };

--- a/lib/utils/data/processing/balanceUtils.ts
+++ b/lib/utils/data/processing/balanceUtils.ts
@@ -7,21 +7,51 @@ import {
 import { BLOCKCYPHER_API_BASE_URL } from "$constants";
 import { formatSatoshisToBTC, formatUSDValue } from "$lib/utils/formatUtils.ts";
 import {
-  fetchWithTimeout,
+  DEFAULT_FETCH_TIMEOUT_MS,
+  fetchJsonWithTimeout,
   getBTCBalanceFromMempool,
 } from "$lib/utils/mempool.ts";
 import { dbManager } from "$server/database/databaseManager.ts";
 
+/**
+ * Default total budget for the BTC-balance provider chain (all providers,
+ * retries and body reads combined). Before this the chain had only per-fetch
+ * deadlines, so the worst case was the SUM of every attempt: two providers
+ * x 5s, plus the mempool retry loop on non-timeout errors (4 x 5s + 3 x 1s
+ * back-off) — 10-23s measured on the aggregate balance endpoint (#1198).
+ */
+export const DEFAULT_BTC_BALANCE_TIMEOUT_MS = DEFAULT_FETCH_TIMEOUT_MS;
+
+/**
+ * Hard ceiling applied by the aggregate `/api/v2/balance/{address}` handler
+ * to its BTC leg. The stamps + SRC-20 legs answer in ~0.3-0.4s, so this keeps
+ * the whole response comfortably under the 5s regression threshold even when
+ * every BTC provider is unresponsive.
+ */
+export const BTC_BALANCE_LEG_CEILING_MS = 3000;
+
+/**
+ * The provider chain is handed `ceiling - grace` so that, when it honours its
+ * own deadline, it reports `unavailable` (providers failed within budget)
+ * rather than tripping the outer ceiling (`timeout`: something outside the
+ * chain's control — e.g. the cache layer — stalled).
+ */
+const BTC_BALANCE_CEILING_GRACE_MS = 200;
+
 async function getBTCBalanceFromBlockCypher(
   address: string,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<BTCBalance | null> {
   try {
-    const response = await fetchWithTimeout(
+    const result = await fetchJsonWithTimeout<
+      BlockCypherAddressBalanceResponse
+    >(
       `${BLOCKCYPHER_API_BASE_URL}/v1/btc/main/addrs/${address}/balance`,
+      timeoutMs,
     );
-    if (!response.ok) return null;
+    if (!result.ok || !result.data) return null;
 
-    const data = await response.json() as BlockCypherAddressBalanceResponse;
+    const data = result.data;
     const confirmed = data.balance || 0;
     const unconfirmed = data.unconfirmed_balance || 0;
 
@@ -41,26 +71,30 @@ async function getBTCBalanceFromBlockCypher(
 // Cached wrapper for getBTCBalanceFromMempool with Redis caching
 async function getCachedBTCBalanceFromMempool(
   address: string,
+  timeoutMs: number,
 ): Promise<BTCBalance | null> {
   const cacheKey = `btc_balance:mempool:${address}`;
   const cacheDuration = 60; // 60 seconds TTL - balances can change frequently
+  const fetchFresh = () =>
+    getBTCBalanceFromMempool(address, 0, Date.now() + timeoutMs);
 
   try {
     return await dbManager.handleCache(
       cacheKey,
-      () => getBTCBalanceFromMempool(address),
+      fetchFresh,
       cacheDuration,
     ) as BTCBalance | null;
   } catch (error) {
     console.error("Cached balance fetch error:", error);
     // Fallback to direct call if caching fails
-    return getBTCBalanceFromMempool(address);
+    return fetchFresh();
   }
 }
 
 // Cached wrapper for getBTCBalanceFromBlockCypher with Redis caching
 async function getCachedBTCBalanceFromBlockCypher(
   address: string,
+  timeoutMs: number,
 ): Promise<BTCBalance | null> {
   const cacheKey = `btc_balance:blockcypher:${address}`;
   const cacheDuration = 60; // 60 seconds TTL
@@ -68,13 +102,13 @@ async function getCachedBTCBalanceFromBlockCypher(
   try {
     return await dbManager.handleCache(
       cacheKey,
-      () => getBTCBalanceFromBlockCypher(address),
+      () => getBTCBalanceFromBlockCypher(address, timeoutMs),
       cacheDuration,
     ) as BTCBalance | null;
   } catch (error) {
     console.error("Cached BlockCypher balance fetch error:", error);
     // Fallback to direct call if caching fails
-    return getBTCBalanceFromBlockCypher(address);
+    return getBTCBalanceFromBlockCypher(address, timeoutMs);
   }
 }
 
@@ -83,22 +117,39 @@ export async function getBTCBalanceInfo(
   options: BTCBalanceInfoOptions = {},
 ): Promise<BTCBalanceInfo | null> {
   try {
-    // Use cached versions of balance providers
+    const totalBudgetMs = options.timeoutMs ?? DEFAULT_BTC_BALANCE_TIMEOUT_MS;
+    const deadlineAt = Date.now() + totalBudgetMs;
+
+    // Use cached versions of balance providers. They run sequentially against
+    // ONE shared deadline: each provider gets an equal share of whatever budget
+    // is left, so a hung first provider cannot starve the fallback, and a
+    // provider that fails fast hands its unused share to the next one.
     const providers = [
       {
         name: "Mempool (cached)",
-        fn: () => getCachedBTCBalanceFromMempool(address),
+        fn: (budgetMs: number) =>
+          getCachedBTCBalanceFromMempool(address, budgetMs),
       },
       {
         name: "BlockCypher (cached)",
-        fn: () => getCachedBTCBalanceFromBlockCypher(address),
+        fn: (budgetMs: number) =>
+          getCachedBTCBalanceFromBlockCypher(address, budgetMs),
       },
     ];
     let balance = null;
 
-    for (const provider of providers) {
+    for (const [index, provider] of providers.entries()) {
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs <= 0) {
+        console.error(
+          `BTC balance budget (${totalBudgetMs}ms) exhausted before ${provider.name}`,
+        );
+        break;
+      }
+      const providersLeft = providers.length - index;
+      const budgetMs = Math.max(1, Math.floor(remainingMs / providersLeft));
       try {
-        const result = await provider.fn();
+        const result = await provider.fn(budgetMs);
         if (result) {
           balance = result;
           console.log(`Using balance data from ${provider.name}`);
@@ -172,4 +223,70 @@ export async function getBTCBalanceInfo(
     console.error("Error in getBTCBalanceInfo:", error);
     return null;
   }
+}
+
+export type BTCBalanceLegStatus = "ok" | "unavailable" | "timeout";
+
+export interface BTCBalanceLegResult {
+  /**
+   * `ok`          — a provider answered inside the budget.
+   * `unavailable` — every provider failed / timed out inside the budget.
+   * `timeout`     — the ceiling fired before the chain returned at all
+   *                 (a stall outside the chain's own deadline, e.g. cache).
+   */
+  status: BTCBalanceLegStatus;
+  info: BTCBalanceInfo | null;
+}
+
+/**
+ * `getBTCBalanceInfo` with a hard wall-clock ceiling. Always resolves — never
+ * rejects — within `ceilingMs`, so an aggregate endpoint can render its other
+ * legs with the `btc` block degraded instead of stalling or 5xx-ing because
+ * a third-party provider is slow. The underlying chain is handed a slightly
+ * shorter budget so it normally reports `unavailable` on its own; `timeout`
+ * only fires if something the chain does not bound (e.g. Redis) stalls. On
+ * `timeout` the in-flight chain is not cancelled: if it eventually succeeds
+ * it still warms the provider cache for the next request.
+ */
+export function getBTCBalanceInfoBounded(
+  address: string,
+  ceilingMs: number = BTC_BALANCE_LEG_CEILING_MS,
+  options: BTCBalanceInfoOptions = {},
+): Promise<BTCBalanceLegResult> {
+  const chainBudgetMs = Math.max(
+    1,
+    Math.min(
+      ceilingMs - BTC_BALANCE_CEILING_GRACE_MS,
+      options.timeoutMs ?? Number.POSITIVE_INFINITY,
+    ),
+  );
+
+  let timeoutId: number | undefined;
+  const ceiling = new Promise<BTCBalanceLegResult>((resolve) => {
+    timeoutId = setTimeout(() => {
+      console.error(
+        `BTC balance leg exceeded ${ceilingMs}ms ceiling for ${address}; responding with degraded btc block`,
+      );
+      resolve({ status: "timeout", info: null });
+    }, ceilingMs);
+  });
+
+  const chain = getBTCBalanceInfo(address, {
+    ...options,
+    timeoutMs: chainBudgetMs,
+  })
+    .then((info): BTCBalanceLegResult => ({
+      status: info ? "ok" : "unavailable",
+      info,
+    }))
+    // getBTCBalanceInfo already swallows errors; this is belt-and-braces so a
+    // provider failure can never surface as a 5xx from the aggregate route.
+    .catch((error): BTCBalanceLegResult => {
+      console.error("BTC balance leg failed:", error);
+      return { status: "unavailable", info: null };
+    });
+
+  return Promise.race([chain, ceiling]).finally(() => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  });
 }

--- a/lib/utils/wallet/ownership.ts
+++ b/lib/utils/wallet/ownership.ts
@@ -1,0 +1,90 @@
+/* ===== WALLET OWNERSHIP HELPERS ===== */
+/**
+ * Canonical "does the connected wallet control this address?" logic.
+ *
+ * Wallets can expose more than one address for the same session. Xverse, for
+ * example, reports a payment address (P2WPKH, `bc1q…`) on `wallet.address`
+ * and an ordinals address (P2TR, `bc1p…`) on `wallet.ordinalsAddress`, and
+ * lists both in `wallet.accounts`. Any owner-gated decision (owner-only UI,
+ * "is this my stamp/token", which address to sign with, …) MUST go through
+ * these helpers instead of comparing `wallet.address` directly, otherwise the
+ * secondary addresses are silently ignored.
+ *
+ * Comparison rules:
+ *   - Bech32 / Bech32m addresses (`bc1…`, `tb1…`, `bcrt1…`) are case-insensitive
+ *     by spec, so they are compared case-insensitively.
+ *   - Base58Check addresses (`1…`, `3…`, `m…`, `n…`, `2…`) are case-sensitive,
+ *     so they are compared exactly.
+ *   - Surrounding whitespace is never significant.
+ */
+import type { Wallet } from "$types/wallet.d.ts";
+
+/** Minimal shape needed to enumerate the addresses a wallet controls. */
+export type WalletAddressSource = Partial<
+  Pick<Wallet, "address" | "ordinalsAddress" | "accounts">
+>;
+
+const BECH32_PREFIX = /^(bc|tb|bcrt)1/i;
+
+function normalizeAddress(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Compare two Bitcoin addresses for equality, honouring the case rules of
+ * each address format (see module docs).
+ */
+export function addressesEqual(a: unknown, b: unknown): boolean {
+  const left = normalizeAddress(a);
+  const right = normalizeAddress(b);
+  if (left === null || right === null) return false;
+  if (left === right) return true;
+  if (BECH32_PREFIX.test(left) && BECH32_PREFIX.test(right)) {
+    return left.toLowerCase() === right.toLowerCase();
+  }
+  return false;
+}
+
+/**
+ * All distinct, non-empty addresses the connected wallet reports as its own:
+ * the primary/payment address, the optional ordinals address, and every entry
+ * of `accounts`. Order is preserved (primary first) and duplicates removed.
+ */
+export function getWalletAddresses(
+  wallet: WalletAddressSource | null | undefined,
+): string[] {
+  if (!wallet) return [];
+  const candidates: unknown[] = [
+    wallet.address,
+    wallet.ordinalsAddress,
+    ...(Array.isArray(wallet.accounts) ? wallet.accounts : []),
+  ];
+  const result: string[] = [];
+  for (const candidate of candidates) {
+    const normalized = normalizeAddress(candidate);
+    if (normalized === null) continue;
+    if (result.some((existing) => addressesEqual(existing, normalized))) {
+      continue;
+    }
+    result.push(normalized);
+  }
+  return result;
+}
+
+/**
+ * True when `address` is one of the addresses controlled by `wallet`.
+ * Returns false for a missing wallet, a disconnected wallet (no addresses),
+ * or an empty/invalid target address.
+ */
+export function walletOwnsAddress(
+  wallet: WalletAddressSource | null | undefined,
+  address: unknown,
+): boolean {
+  const target = normalizeAddress(address);
+  if (target === null) return false;
+  return getWalletAddresses(wallet).some((owned) =>
+    addressesEqual(owned, target)
+  );
+}

--- a/routes/api/_middleware.ts
+++ b/routes/api/_middleware.ts
@@ -178,16 +178,14 @@ export async function handler(
         method: req.method,
         error: error.message,
       });
-      return new Response(
-        JSON.stringify({
+      return ApiResponseUtil.custom(
+        {
           status: "error",
           message: "Request timeout - the operation took too long to complete",
           error: "GATEWAY_TIMEOUT",
-        }),
-        {
-          status: 504,
-          headers: { "Content-Type": "application/json" },
         },
+        504,
+        { forceNoCache: true },
       );
     }
 

--- a/routes/api/v2/balance/[address].ts
+++ b/routes/api/v2/balance/[address].ts
@@ -1,7 +1,10 @@
 import { Handlers } from "$fresh/server.ts";
 import type { AddressHandlerContext } from "$types/api.d.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
-import { getBTCBalanceInfo } from "$lib/utils/data/processing/balanceUtils.ts";
+import {
+  BTC_BALANCE_LEG_CEILING_MS,
+  getBTCBalanceInfoBounded,
+} from "$lib/utils/data/processing/balanceUtils.ts";
 import { getPaginationParams } from "$lib/utils/data/pagination/paginationUtils.ts";
 import { isValidBitcoinAddress } from "$lib/utils/typeGuards.ts";
 import { Src20Controller } from "$server/controller/src20Controller.ts";
@@ -52,8 +55,14 @@ export const handler: Handlers<AddressHandlerContext> = {
         page = DEFAULT_PAGINATION.page,
       } = pagination;
 
-      // Call controllers directly instead of making HTTP requests to avoid DNS issues
-      const [stamps, src20, btcInfo] = await Promise.all([
+      // Call controllers directly instead of making HTTP requests to avoid DNS issues.
+      //
+      // The BTC leg talks to third-party providers (mempool.space / BlockCypher)
+      // and is the only leg that can be slow; it is hard-capped so that a slow
+      // or rate-limiting provider degrades the `btc` block instead of stalling
+      // the stamps + SRC-20 data behind it (#1198). `btcLeg.status` is surfaced
+      // via the `X-BTC-Balance-Status` header; the response schema is unchanged.
+      const [stamps, src20, btcLeg] = await Promise.all([
         StampController.getStampBalancesByAddress(address, limit, page),
         Src20Controller.handleSrc20BalanceRequest({
           address,
@@ -61,8 +70,9 @@ export const handler: Handlers<AddressHandlerContext> = {
           page,
           includePagination: true,
         }),
-        getBTCBalanceInfo(address),
+        getBTCBalanceInfoBounded(address, BTC_BALANCE_LEG_CEILING_MS),
       ]);
+      const btcInfo = btcLeg.info;
 
       // NOTE: deliberately NO 404 for "valid address, zero holdings".
       //
@@ -114,6 +124,8 @@ export const handler: Handlers<AddressHandlerContext> = {
             "/api/v2/stamps/balance/[address], /api/v2/src20/balance/[address]",
           "X-Info":
             "Consider using dedicated endpoints for better performance and pagination control",
+          // ok | unavailable | timeout — when not "ok" the btc block is zeros.
+          "X-BTC-Balance-Status": btcLeg.status,
         },
       });
     } catch (error) {

--- a/routes/api/v2/keys/index.ts
+++ b/routes/api/v2/keys/index.ts
@@ -74,15 +74,15 @@ export const handler: Handlers = {
         await redis.pexpire(signupKey, 60 * 60 * 1000);
       }
       if (signupCount > 3) {
-        return new Response(
-          JSON.stringify({
+        return ApiResponseUtil.custom(
+          {
             error: "Too many signup attempts. Limit: 3 per hour per IP.",
             retryAfter: 3600,
-          }),
+          },
+          429,
           {
-            status: 429,
+            ...noCache,
             headers: {
-              "Content-Type": "application/json",
               "Retry-After": "3600",
               "Cache-Control": "no-store",
             },
@@ -108,18 +108,13 @@ export const handler: Handlers = {
       if (
         msg.includes("Duplicate entry") || msg.includes("unique constraint")
       ) {
-        return new Response(
-          JSON.stringify({
+        return ApiResponseUtil.custom(
+          {
             error: "An API key already exists for this email address.",
             code: "DUPLICATE_EMAIL",
-          }),
-          {
-            status: 409,
-            headers: {
-              "Content-Type": "application/json",
-              "Cache-Control": "no-store",
-            },
           },
+          409,
+          { ...noCache, headers: { "Cache-Control": "no-store" } },
         );
       }
 

--- a/routes/handlers/sharedContentHandler.ts
+++ b/routes/handlers/sharedContentHandler.ts
@@ -119,17 +119,18 @@ export async function handleContentRequest(
     const contentType = response.headers.get("content-type") || "";
     if (response.ok && contentType.includes("text/html")) {
       const body = await response.text();
-      const headers = new Headers(response.headers);
-      headers.set("Cache-Control", "public, max-age=3600, no-transform");
-      headers.set("CDN-Cache-Control", "public, max-age=86400");
-      // Override Vary to only include CF-supported values.
-      // Default "X-API-Version" in Vary causes CF to skip caching.
-      headers.set("Vary", "Accept-Encoding");
-      headers.set("X-Frame-Options", "SAMEORIGIN");
-      headers.set("X-Content-Type-Options", "nosniff");
-      return new Response(body, {
-        status: response.status,
-        headers,
+      return WebResponseUtil.modifiedResponse(body, response, {
+        headers: {
+          "Cache-Control": "public, max-age=3600, no-transform",
+          "CDN-Cache-Control": "public, max-age=86400",
+          // Override Vary to only include CF-supported values.
+          // Default "X-API-Version" in Vary causes CF to skip caching.
+          "Vary": "Accept-Encoding",
+          "X-Frame-Options": "SAMEORIGIN",
+          "X-Content-Type-Options": "nosniff",
+        },
+        // Keep normalizeHeaders from re-adding X-API-Version/Origin to Vary.
+        immutableBinary: true,
       });
     }
 

--- a/routes/sitemap.xml.ts
+++ b/routes/sitemap.xml.ts
@@ -1,6 +1,12 @@
 import { Handlers } from "$fresh/server.ts";
+import { WebResponseUtil } from "$lib/utils/api/responses/webResponseUtil.ts";
 
 const SITE_URL = "https://stampchain.io";
+
+// Sitemap is regenerated on every request (lastmod = today), so cap all
+// cache layers at one hour instead of the 1-year immutable default.
+const SITEMAP_CACHE_SECONDS = 3600;
+const SITEMAP_CACHE_CONTROL = `public, max-age=${SITEMAP_CACHE_SECONDS}`;
 
 // Static pages with their priorities and change frequencies
 const STATIC_PAGES: Array<{
@@ -58,10 +64,13 @@ ${urls}
 export const handler: Handlers = {
   GET(_req, _ctx) {
     const xml = generateSitemapXml();
-    return new Response(xml, {
+    return WebResponseUtil.xmlResponse(xml, {
       headers: {
-        "Content-Type": "application/xml; charset=utf-8",
-        "Cache-Control": "public, max-age=3600",
+        "Cache-Control": SITEMAP_CACHE_CONTROL,
+        "CDN-Cache-Control": SITEMAP_CACHE_CONTROL,
+        "Cloudflare-CDN-Cache-Control": SITEMAP_CACHE_CONTROL,
+        "Surrogate-Control": `max-age=${SITEMAP_CACHE_SECONDS}`,
+        "Edge-Control": `cache-maxage=${SITEMAP_CACHE_SECONDS}`,
       },
     });
   },

--- a/schema.yml
+++ b/schema.yml
@@ -346,6 +346,38 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v2/counterparty/version:
+    get:
+      operationId: getCounterpartyVersion
+      tags:
+        - System
+      summary: Get the Counterparty node version
+      description: |
+        Queries the configured Counterparty v2 API nodes in order and returns the
+        version string reported by the first reachable node. The response is never cached.
+      responses:
+        "200":
+          description: Version of the first reachable Counterparty node
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - version
+                properties:
+                  version:
+                    type: string
+                    description: Counterparty node version string
+                    example: "11.3.0"
+        "503":
+          description: No Counterparty node could be reached
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: "Unable to fetch Counterparty version"
+
   /api/v2/error:
     get:
       operationId: testErrorResponse
@@ -571,6 +603,50 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v2/balance/getStampsBalance:
+    get:
+      operationId: getStampsBalanceByQuery
+      tags:
+        - Balance
+      summary: Get raw Counterparty stamp balances for an address
+      description: |
+        Returns the Counterparty asset balances (stamps) held by an address, as reported by
+        the Counterparty v2 API. Unlike /api/v2/stamps/balance/{address} the result is not
+        enriched with stamp metadata and is not paginated.
+      parameters:
+        - in: query
+          name: address
+          required: true
+          schema:
+            type: string
+          example: "bc1qhy8y5hajwqz56nzuqyqe9ghsvsxjkl3akmdrqp"
+          description: The Bitcoin address to query
+        - in: query
+          name: utxoOnly
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When "true", only balances attached to UTXOs are returned
+      responses:
+        "200":
+          description: Counterparty balances for the address
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - stampBalance
+                properties:
+                  stampBalance:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/XcpBalance"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /api/v2/block/{block_index}:
     get:
       operationId: getBlockInfo
@@ -770,6 +846,58 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v2/collections/by-name/{name}:
+    get:
+      operationId: getCollectionByName
+      tags:
+        - Collections
+      summary: Get collection summary by name
+      description: |
+        Looks up a single collection by its exact collection name and returns its
+        aggregate summary (creators, stamp count, total editions). Use
+        /api/v2/collections/{id} for the paginated stamp list and market data.
+      parameters:
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+          example: "KEVIN"
+          description: Exact collection name
+      responses:
+        "200":
+          description: Collection summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  collection_id:
+                    type: string
+                    description: Collection UUID (32 hex characters)
+                  collection_name:
+                    type: string
+                  collection_description:
+                    type: string
+                    nullable: true
+                  creators:
+                    type: array
+                    items:
+                      type: string
+                    description: Creator addresses
+                  stamp_count:
+                    type: integer
+                    description: Number of distinct stamps in the collection
+                  total_editions:
+                    type: number
+                    description: Sum of editions across all stamps in the collection
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /api/v2/cursed:
     get:
       operationId: getCursedStamps
@@ -826,6 +954,29 @@ paths:
           $ref: "#/components/responses/Gone"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/cursed/block:
+    get:
+      operationId: getCursedStampsByLatestBlock
+      deprecated: true
+      tags:
+        - Cursed Stamps
+      summary: Get cursed stamps in the latest block
+      description: |
+        Returns block info and the cursed stamps created in the most recent indexed block.
+        Deprecated in API v2.3 (the default version): requests return 410 Gone unless a
+        legacy API-Version header (2.2 or lower) is sent.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StampBlockResponseBody"
+        "410":
+          $ref: "#/components/responses/Gone"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -1082,6 +1233,82 @@ paths:
                 $ref: "#/components/schemas/PaginatedSrc20ResponseBody"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/src20/search:
+    get:
+      operationId: searchSrc20Tokens
+      tags:
+        - SRC-20
+      summary: Search SRC-20 tokens
+      description: |
+        Searches deployed SRC-20 tokens by tick (partial match) or by deploy tx_hash.
+        Returns at most 10 results, with exact-prefix tick matches first. An empty or
+        unrecognised query returns an empty list.
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+          example: "KEVIN"
+          description: Search term (tick or tx_hash)
+        - in: query
+          name: mintable_only
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When "true", only tokens that are not yet fully minted are returned
+      responses:
+        "200":
+          description: Matching SRC-20 tokens
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Src20SearchResult"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/src20/{op}:
+    get:
+      operationId: getSrc20TransactionsByOp
+      tags:
+        - SRC-20
+      summary: Get paginated SRC-20 transactions filtered by operation
+      description: |
+        Returns valid SRC-20 transactions for a single operation type. The op segment is
+        case-insensitive (deploy, mint, transfer). This is the basic transaction listing
+        without the market-data enrichment of /api/v2/src20.
+      parameters:
+        - in: path
+          name: op
+          required: true
+          schema:
+            type: string
+            enum: [deploy, mint, transfer]
+          example: "mint"
+          description: SRC-20 operation type (case-insensitive)
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/Sort"
+      responses:
+        "200":
+          description: Paginated SRC-20 transactions for the operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedSrc20ResponseBody"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -1387,6 +1614,45 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/src20/tick/{tick}/mintData:
+    get:
+      operationId: getSrc20TickMintData
+      tags:
+        - SRC-20
+      summary: Get mint progress and holder count for a tick
+      description: |
+        Returns the minting progress of an SRC-20 token together with the number of
+        holders. mintStatus is null when the tick has no DEPLOY record.
+      parameters:
+        - in: path
+          name: tick
+          required: true
+          schema:
+            type: string
+          example: "KEVIN"
+          description: Tick value (URL-encoded if it contains emoji)
+      responses:
+        "200":
+          description: Mint progress and holder count
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - mintStatus
+                  - holders
+                properties:
+                  mintStatus:
+                    $ref: "#/components/schemas/SRC20MintProgress"
+                    nullable: true
+                  holders:
+                    type: integer
+                    description: Number of addresses holding the token
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -2438,6 +2704,23 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v2/stamps/block:
+    get:
+      operationId: getStampsByLatestBlock
+      tags:
+        - Stamps
+      summary: Get stamps in the latest block
+      description: Returns block info and the stamps created in the most recent indexed block.
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StampBlockResponseBody"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /api/v2/stamps/block/{block_index}:
     get:
       operationId: getStampsByBlock
@@ -2575,6 +2858,81 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v2/stamp/{stamp}/preview:
+    get:
+      operationId: getStampPreview
+      tags:
+        - Stamps
+      summary: Get a 1200x1200 social-media preview image for a stamp
+      description: |
+        Renders (and caches) a 1200x1200 PNG preview of the stamp content. Depending on the
+        storage backend the image is either returned inline (image/png) or served via a 302
+        redirect to the CDN copy. When rendering fails the endpoint 302-redirects to the
+        generic Stampchain logo, or returns 404 when placeholderOnFail=true. With
+        format=gif an animated GIF is generated for animated HTML stamps; non-animated
+        stamps redirect to the PNG preview instead.
+      parameters:
+        - in: path
+          name: stamp
+          required: true
+          schema:
+            type: string
+          example: "1"
+          description: Stamp number, cpid, or tx_hash
+        - in: query
+          name: format
+          required: false
+          schema:
+            type: string
+            enum: [png, gif]
+            default: png
+          description: Preview format
+        - in: query
+          name: refresh
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When "true", discards any cached preview and re-renders
+        - in: query
+          name: placeholderOnFail
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: When "true", return 404 instead of redirecting to the fallback logo on render failure
+      responses:
+        "200":
+          description: Rendered PNG preview
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "302":
+          description: Redirect to the CDN-hosted preview image or to the fallback logo
+          headers:
+            Location:
+              schema:
+                type: string
+              description: URL of the preview image (or the fallback logo)
+            X-Fallback:
+              schema:
+                type: string
+              description: Present only on fallback redirects; reason the render failed
+        "400":
+          description: Unsupported format parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Preview unavailable (only when placeholderOnFail=true)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/v2/src20/create:
     post:
       operationId: createSrc20Token
@@ -2675,6 +3033,81 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/src20/multisig/{operation}:
+    post:
+      operationId: createSrc20MultisigTransaction
+      tags:
+        - Minting
+        - SRC-20
+      summary: Build a multisig-encoded SRC-20 deploy, mint, or transfer PSBT
+      description: |
+        Builds an unsigned PSBT that encodes the SRC-20 operation using bare multisig
+        outputs (legacy encoding) instead of the OLGA/P2WSH encoding used by
+        /api/v2/src20/create. The operation-specific fields are validated by the
+        operation (mint checks minted-out, transfer checks the sender balance).
+      parameters:
+        - in: path
+          name: operation
+          required: true
+          schema:
+            type: string
+            enum: [deploy, mint, transfer]
+          description: SRC-20 operation (case-insensitive)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/SRC20MultisigDeployRequest"
+                - $ref: "#/components/schemas/SRC20MultisigMintRequest"
+                - $ref: "#/components/schemas/SRC20MultisigTransferRequest"
+            examples:
+              mint:
+                summary: Mint example
+                value:
+                  network: "mainnet"
+                  toAddress: "bc1ql49ydapnjafl5t2cp9zqpjwe6pdgmxy98859v2"
+                  changeAddress: "bc1ql49ydapnjafl5t2cp9zqpjwe6pdgmxy98859v2"
+                  feeRate: 20
+                  tick: "KEVIN"
+                  amt: "1000"
+      responses:
+        "200":
+          description: Unsigned multisig PSBT
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hex:
+                    type: string
+                    description: Hex-encoded PSBT
+                  base64:
+                    type: string
+                    description: Base64-encoded PSBT
+                  inputsToSign:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        index:
+                          type: integer
+                          description: PSBT input index to sign
+                  est_tx_size:
+                    type: integer
+                    description: Estimated transaction size in vbytes
+                  est_miner_fee:
+                    type: string
+                    description: Estimated miner fee in satoshis (stringified)
+                  change_value:
+                    type: string
+                    description: Change returned to changeAddress in satoshis (stringified)
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -2787,6 +3220,35 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /api/v2/olga/estimate:
+    post:
+      operationId: estimateStampMintFee
+      tags:
+        - Minting
+        - Stamps
+      summary: Estimate the cost of minting a stamp
+      description: |
+        Estimates transaction size, miner fee, dust, and total cost for minting the given
+        file as a stamp, using dummy UTXOs instead of the caller's wallet. No transaction
+        is built.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EstimateRequest"
+      responses:
+        "200":
+          description: Fee estimate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EstimateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /api/v2/trx/stampdetach:
     post:
       operationId: detachStampFromUtxo
@@ -2846,6 +3308,445 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/trx/create_psbt:
+    post:
+      operationId: createSellerPsbt
+      tags:
+        - Stamps
+      summary: Create a seller-side PSBT for a UTXO sale
+      description: |
+        Builds a partially signed transaction offering the given UTXO for salePrice
+        satoshis payable to sellerAddress. The buyer completes it via /api/v2/trx/complete_psbt.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - utxo
+                - salePrice
+                - sellerAddress
+              properties:
+                utxo:
+                  type: string
+                  description: UTXO to sell in txid:vout format
+                  example: "10f8e495a5088dd90a731f4b2657bfb4e94b1f59d3961cbc960900d4e5ba44e5:0"
+                salePrice:
+                  type: number
+                  description: Sale price in satoshis (must be > 0)
+                  example: 100000
+                sellerAddress:
+                  type: string
+                  description: Address that receives the sale proceeds
+      responses:
+        "200":
+          description: Seller PSBT
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - psbt
+                properties:
+                  psbt:
+                    type: string
+                    description: Hex-encoded PSBT
+                  fee:
+                    type: number
+                    description: Fee in satoshis (currently a placeholder value)
+                  inputCount:
+                    type: integer
+                  outputCount:
+                    type: integer
+                  estimatedSize:
+                    type: integer
+                    description: Estimated size in bytes (currently a placeholder value)
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/trx/complete_psbt:
+    post:
+      operationId: completeSellerPsbt
+      tags:
+        - Stamps
+      summary: Complete a seller PSBT with the buyer's funding input
+      description: |
+        Adds the buyer's UTXO and change output to a seller PSBT produced by
+        /api/v2/trx/create_psbt, at the requested fee rate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sellerPsbtHex
+                - buyerUtxo
+                - buyerAddress
+                - feeRate
+              properties:
+                sellerPsbtHex:
+                  type: string
+                  description: Hex-encoded seller PSBT
+                buyerUtxo:
+                  type: string
+                  description: Buyer funding UTXO in txid:vout format
+                buyerAddress:
+                  type: string
+                  description: Buyer address (receives change)
+                feeRate:
+                  type: number
+                  description: Fee rate in satoshis per vbyte
+      responses:
+        "200":
+          description: Completed PSBT
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - completedPsbt
+                properties:
+                  completedPsbt:
+                    type: string
+                    description: Hex-encoded completed PSBT
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/create/send:
+    post:
+      operationId: createSendTransaction
+      tags:
+        - Stamps
+      summary: Build a Counterparty asset send PSBT
+      description: |
+        Composes a Counterparty send of the given asset via the Counterparty API and
+        reconstructs it as an unsigned PSBT for the wallet to sign. Fee precedence:
+        options.fee_per_kb, then satsPerVB, then the live mempool recommended rate.
+        With dryRun=true only the Counterparty-estimated fee is returned.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - address
+                - destination
+                - asset
+                - quantity
+              properties:
+                address:
+                  type: string
+                  description: Sender address (funds the transaction)
+                destination:
+                  type: string
+                  description: Recipient address
+                asset:
+                  type: string
+                  description: Counterparty asset name (cpid)
+                quantity:
+                  type: number
+                  description: Quantity to send in the asset's base units (must be > 0)
+                satsPerVB:
+                  type: number
+                  description: Fee rate in satoshis per vbyte
+                dryRun:
+                  type: boolean
+                  default: false
+                  description: When true, return only the fee estimate without a PSBT
+                options:
+                  type: object
+                  properties:
+                    fee_per_kb:
+                      type: number
+                      description: Explicit fee rate in satoshis per kilobyte (overrides satsPerVB)
+                    encoding:
+                      type: string
+                      default: opreturn
+                      description: Counterparty data encoding
+                    memo:
+                      type: string
+                    memo_is_hex:
+                      type: boolean
+      responses:
+        "200":
+          description: Unsigned send PSBT, or fee estimate when dryRun=true
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    title: SendPsbt
+                    properties:
+                      psbtHex:
+                        type: string
+                        description: Hex-encoded unsigned PSBT
+                      inputsToSign:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/InputToSign"
+                      estimatedFee:
+                        type: number
+                        description: Fee estimated by Counterparty in satoshis
+                  - type: object
+                    title: SendDryRun
+                    properties:
+                      estimatedFee:
+                        type: number
+                        description: Fee estimated by Counterparty in satoshis
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/create/dispense:
+    post:
+      operationId: createDispenseTransaction
+      tags:
+        - Dispensers
+      summary: Build a PSBT that buys from a dispenser
+      description: |
+        Composes a Counterparty dispense (BTC payment to a dispenser) and reconstructs it
+        as an unsigned PSBT for the buyer's wallet to sign, optionally splicing the
+        operator service fee out of the change output. With dryRun=true a fixed-size
+        numeric fee estimate is returned instead. All handled failures, including
+        Counterparty compose errors and malformed bodies, return 400.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - address
+                - dispenser
+                - quantity
+                - options
+              properties:
+                address:
+                  type: string
+                  description: Buyer address (funds the transaction and receives change)
+                dispenser:
+                  type: string
+                  description: Dispenser address
+                quantity:
+                  type: number
+                  description: BTC amount to pay to the dispenser, in satoshis
+                dryRun:
+                  type: boolean
+                  default: false
+                  description: When true, return a numeric estimate without composing a PSBT
+                options:
+                  type: object
+                  description: Fee and Counterparty compose options; satsPerVB or fee_per_kb is required unless dryRun=true
+                  properties:
+                    satsPerVB:
+                      type: number
+                      description: Fee rate in satoshis per vbyte
+                    fee_per_kb:
+                      type: number
+                      description: Fee rate in satoshis per kilobyte
+                    allow_unconfirmed_inputs:
+                      type: boolean
+                      default: true
+                    validate:
+                      type: boolean
+                      default: true
+                    verbose:
+                      type: boolean
+                      default: true
+      responses:
+        "200":
+          description: Unsigned dispense PSBT, or fee estimate when dryRun=true
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    title: DispensePsbt
+                    properties:
+                      psbt:
+                        type: string
+                        description: Hex-encoded unsigned PSBT
+                      inputsToSign:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/InputToSign"
+                      estimatedFee:
+                        type: number
+                        description: Total fee (Counterparty network fee plus service fee) in satoshis
+                      estimatedVsize:
+                        type: number
+                        description: Virtual size of the Counterparty-composed transaction
+                      finalBuyerChange:
+                        type: number
+                        description: Change returned to the buyer in satoshis (0 if dropped as dust)
+                  - allOf:
+                      - $ref: "#/components/schemas/DryRunFeeEstimate"
+                      - type: object
+                        title: DispenseDryRun
+                        properties:
+                          dispenser_payment:
+                            type: number
+                            description: Amount paid to the dispenser in satoshis
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /api/v2/fairmint:
+    get:
+      operationId: getFairminters
+      tags:
+        - Minting
+      summary: List all Counterparty fairminters
+      description: |
+        Returns every fairminter known to the Counterparty API (all pages are fetched
+        server-side). The response is a bare array and can be large.
+      responses:
+        "200":
+          description: Fairminter list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Fairminter"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/fairmint/compose:
+    post:
+      operationId: composeFairmint
+      tags:
+        - Minting
+      summary: Build a fairmint PSBT
+      description: |
+        Composes a Counterparty fairmint for the given asset and reconstructs it as an
+        unsigned PSBT, optionally splicing a service fee out of the change output.
+        quantity is required for paid fairminters and ignored for free ones. Any
+        additional body fields are forwarded to the Counterparty compose call. With
+        dryRun=true a fixed-size numeric fee estimate is returned instead.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - address
+                - asset
+              properties:
+                address:
+                  type: string
+                  description: Minter address (funds the transaction and receives the minted asset)
+                asset:
+                  type: string
+                  description: Fairminter asset name
+                quantity:
+                  type: number
+                  description: Quantity to mint; required for paid fairminters, must be omitted for free ones
+                satsPerVB:
+                  type: number
+                  description: Fee rate in satoshis per vbyte (satsPerVB or satsPerKB is required)
+                satsPerKB:
+                  type: number
+                  description: Fee rate in satoshis per kilobyte
+                service_fee:
+                  type: number
+                  description: Service fee in satoshis; defaults to the server-configured fee
+                service_fee_address:
+                  type: string
+                  description: Service fee recipient; defaults to the server-configured address
+                dryRun:
+                  type: boolean
+                  default: false
+      responses:
+        "200":
+          description: Unsigned fairmint PSBT, or fee estimate when dryRun=true
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    title: FairmintPsbt
+                    properties:
+                      psbtHex:
+                        type: string
+                        description: Hex-encoded unsigned PSBT
+                      inputsToSign:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/InputToSign"
+                      estimatedFee:
+                        type: number
+                        description: Total fee (Counterparty network fee plus service fee) in satoshis
+                      estimatedVsize:
+                        type: number
+                        description: Virtual size of the Counterparty-composed transaction
+                      totalInputValue:
+                        type: string
+                        description: Sum of the user's inputs in satoshis (stringified)
+                      totalOutputValue:
+                        type: string
+                        description: Sum of all outputs in satoshis (stringified)
+                      finalUserChange:
+                        type: string
+                        description: Change returned to the minter in satoshis (stringified, "0" if dropped as dust)
+                  - $ref: "#/components/schemas/DryRunFeeEstimate"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /api/v2/utxo/ancestors/{address}:
+    get:
+      operationId: getUtxoAncestors
+      tags:
+        - UTXO
+      summary: Get unconfirmed ancestor data for an address's UTXOs
+      description: |
+        Lists the mempool ancestor fee/size data for each spendable (non-stamp) UTXO of
+        the address that has unconfirmed ancestors. UTXOs without ancestors are omitted.
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+          example: "bc1qhy8y5hajwqz56nzuqyqe9ghsvsxjkl3akmdrqp"
+          description: Bitcoin address
+      responses:
+        "200":
+          description: Ancestor data per UTXO with unconfirmed ancestors
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ancestors
+                properties:
+                  ancestors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        fees:
+                          type: number
+                          description: Total ancestor fees in satoshis
+                        vsize:
+                          type: number
+                          description: Total ancestor virtual size
+                        weight:
+                          type: number
+                          description: Total ancestor weight (vsize * 4)
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -4268,6 +5169,373 @@ components:
           $ref: "#/components/schemas/CollectionMarketData"
           nullable: true
           description: Aggregated market data for the collection from collection_market_data table
+
+    XcpBalance:
+      type: object
+      description: Counterparty asset balance as returned by the Counterparty v2 API
+      properties:
+        address:
+          type: string
+          nullable: true
+          description: Owning address, or the UTXO's address for UTXO-attached balances
+        cpid:
+          type: string
+          description: Counterparty asset name
+        quantity:
+          type: number
+          description: Balance quantity in the asset's base units
+        utxo:
+          type: string
+          description: txid:vout the balance is attached to, or empty string
+        utxo_address:
+          type: string
+          description: Address of the attached UTXO, or empty string
+        divisible:
+          type: boolean
+        assetName:
+          type: string
+          description: Same as cpid
+        balance:
+          type: number
+          description: Same as quantity
+
+    Src20SearchResult:
+      type: object
+      description: SRC-20 deploy matched by /api/v2/src20/search
+      properties:
+        tick:
+          type: string
+        tx_hash:
+          type: string
+          description: Deploy transaction hash
+        max_supply:
+          type: number
+        lim:
+          type: string
+          nullable: true
+          description: Per-mint limit
+        decimals:
+          type: number
+        total_mints:
+          type: number
+        total_minted:
+          type: number
+        progress:
+          type: number
+          description: Mint progress percentage
+        holders:
+          type: number
+        max:
+          type: string
+          nullable: true
+        amt:
+          type: string
+          nullable: true
+        stamp_url:
+          type: string
+          description: URL of the deploy stamp image
+
+    SRC20MintProgress:
+      type: object
+      description: Mint progress for an SRC-20 token, as returned inside /api/v2/src20/tick/{tick}/mintData
+      properties:
+        max_supply:
+          type: string
+        total_minted:
+          type: string
+        limit:
+          type: string
+          description: Per-mint limit
+        total_mints:
+          type: number
+          description: Number of MINT transactions
+        progress:
+          type: string
+          description: Mint progress percentage (3 decimal places)
+        decimals:
+          type: number
+        holders:
+          type: number
+        tx_hash:
+          type: string
+          description: Deploy transaction hash
+        tick:
+          type: string
+        stamp_url:
+          type: string
+          nullable: true
+          description: URL of the deploy stamp image
+
+    Fairminter:
+      type: object
+      description: Counterparty fairminter record
+      properties:
+        tx_hash:
+          type: string
+        tx_index:
+          type: integer
+        block_index:
+          type: integer
+        source:
+          type: string
+        asset:
+          type: string
+        asset_parent:
+          type: string
+          nullable: true
+        asset_longname:
+          type: string
+          nullable: true
+        description:
+          type: string
+        price:
+          type: number
+        quantity_by_price:
+          type: number
+        hard_cap:
+          type: number
+        burn_payment:
+          type: boolean
+        max_mint_per_tx:
+          type: number
+        premint_quantity:
+          type: number
+        start_block:
+          type: integer
+        end_block:
+          type: integer
+        minted_asset_commission_int:
+          type: number
+        soft_cap:
+          type: number
+        soft_cap_deadline_block:
+          type: integer
+        lock_description:
+          type: boolean
+        lock_quantity:
+          type: boolean
+        divisible:
+          type: boolean
+        pre_minted:
+          type: boolean
+        status:
+          type: string
+        paid_quantity:
+          type: number
+          nullable: true
+        confirmed:
+          type: boolean
+
+    InputToSign:
+      type: object
+      description: PSBT input the wallet must sign
+      properties:
+        index:
+          type: integer
+          description: PSBT input index
+        address:
+          type: string
+          description: Address that owns the input
+        sighashTypes:
+          type: array
+          items:
+            type: integer
+
+    DryRunFeeEstimate:
+      type: object
+      description: Numeric fee estimate returned by compose endpoints when dryRun=true
+      properties:
+        est_miner_fee:
+          type: number
+          description: Estimated miner fee in satoshis
+        total_dust_value:
+          type: number
+          description: Total dust value in satoshis
+        total_cost:
+          type: number
+          description: Estimated total cost in satoshis
+        est_tx_size:
+          type: number
+          description: Assumed transaction size in bytes
+        service_fee:
+          type: number
+          description: Service fee in satoshis
+        feeDetails:
+          type: object
+          properties:
+            total:
+              type: number
+            effectiveFeeRate:
+              type: number
+            estimatedSize:
+              type: number
+        is_estimate:
+          type: boolean
+        estimation_method:
+          type: string
+          example: dryRun_calculation
+
+    EstimateRequest:
+      type: object
+      required:
+        - filename
+        - file
+      properties:
+        filename:
+          type: string
+        file:
+          type: string
+          description: Base64-encoded file content
+        qty:
+          oneOf:
+            - type: number
+            - type: string
+        satsPerVB:
+          oneOf:
+            - type: number
+            - type: string
+          description: Fee rate in satoshis per vbyte
+        satsPerKB:
+          oneOf:
+            - type: number
+            - type: string
+          description: Fee rate in satoshis per kilobyte
+        feeRate:
+          oneOf:
+            - type: number
+            - type: string
+          description: Legacy alias for satsPerKB, used only when neither satsPerVB nor satsPerKB is set
+        service_fee:
+          oneOf:
+            - type: number
+            - type: string
+          description: Service fee in satoshis (non-numeric values are treated as 0)
+        isPoshStamp:
+          type: boolean
+
+    EstimateResponse:
+      type: object
+      properties:
+        est_tx_size:
+          type: number
+          description: Estimated transaction size in vbytes
+        total_dust_value:
+          type: number
+          description: Dust across all CIP33 data outputs in satoshis
+        est_miner_fee:
+          type: number
+          description: Estimated miner fee in satoshis
+        total_cost:
+          type: number
+          description: Miner fee plus dust plus service fee in satoshis
+        fee_breakdown:
+          type: object
+          properties:
+            miner_fee:
+              type: number
+            dust_value:
+              type: number
+            service_fee:
+              type: number
+        file_info:
+          type: object
+          properties:
+            size_bytes:
+              type: number
+            cip33_addresses_count:
+              type: number
+        is_estimate:
+          type: boolean
+        estimation_method:
+          type: string
+          example: dummy_utxos
+        dummy_utxo_value:
+          type: number
+          description: Value of the dummy UTXOs assumed for the estimate, in satoshis
+
+    SRC20MultisigBaseRequest:
+      type: object
+      required:
+        - network
+        - changeAddress
+        - toAddress
+        - feeRate
+        - tick
+      properties:
+        network:
+          type: string
+          description: "\"testnet\" selects the Bitcoin testnet; any other value selects mainnet"
+          example: mainnet
+        changeAddress:
+          type: string
+        toAddress:
+          type: string
+          description: Recipient of the SRC-20 operation output
+        feeRate:
+          type: number
+          description: Fee rate in satoshis per vbyte
+        enableRBF:
+          type: boolean
+          default: true
+        tick:
+          type: string
+
+    SRC20MultisigDeployRequest:
+      allOf:
+        - $ref: "#/components/schemas/SRC20MultisigBaseRequest"
+        - type: object
+          required:
+            - max
+            - lim
+          properties:
+            max:
+              type: string
+            lim:
+              type: string
+            dec:
+              type: integer
+              description: Decimals (0-17); omitted from the payload when outside this range
+            x:
+              type: string
+            web:
+              type: string
+            email:
+              type: string
+            tg:
+              type: string
+            description:
+              type: string
+            desc:
+              type: string
+              description: Alias for description
+            img:
+              type: string
+            icon:
+              type: string
+
+    SRC20MultisigMintRequest:
+      allOf:
+        - $ref: "#/components/schemas/SRC20MultisigBaseRequest"
+        - type: object
+          required:
+            - amt
+          properties:
+            amt:
+              type: string
+
+    SRC20MultisigTransferRequest:
+      allOf:
+        - $ref: "#/components/schemas/SRC20MultisigBaseRequest"
+        - type: object
+          required:
+            - fromAddress
+            - amt
+          properties:
+            fromAddress:
+              type: string
+              description: Sender address (its balance is checked)
+            amt:
+              type: string
 
     ErrorResponseBody:
       type: object

--- a/scripts/validate-expected-changes-config.json
+++ b/scripts/validate-expected-changes-config.json
@@ -40,14 +40,10 @@
     "allowAdditionalProperties": true,
     "ignoreEndpoints": [
       "/api/v2/error",
-      "/api/internal/",
-      "/api/v2/create/dispense",
-      "/api/v2/fairmint/compose"
+      "/api/internal/"
     ],
     "ignoreEndpointsNotes": {
-      "/api/internal/": "Frontend-only endpoints behind InternalApiFrontendGuard; intentionally undocumented, return 403 to non-browser callers.",
-      "/api/v2/create/dispense": "POST compose endpoint not yet documented in schema.yml (tracked in TaskMaster stampchain-io).",
-      "/api/v2/fairmint/compose": "POST compose endpoint not yet documented in schema.yml; prod currently 500s after ~27s for unknown assets (tracked as 1174@stampchain-io)."
+      "/api/internal/": "Frontend-only endpoints behind InternalApiFrontendGuard; intentionally undocumented, return 403 to non-browser callers."
     }
   },
   "performance": {

--- a/tests/unit/cryptoUtils.bip322-p2tr.test.ts
+++ b/tests/unit/cryptoUtils.bip322-p2tr.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Server-side signature verification for owner actions signed with a
+ * taproot (P2TR) address, as produced by Xverse's ordinals address via
+ * BIP-322. Guards the contract relied on by EditCreatorNameModal: the
+ * signature must verify against the *resource* address being updated, and
+ * a signature from one of the wallet's addresses must never verify against
+ * another of its addresses.
+ *
+ * Vectors were generated once with bip322-js Signer from a throwaway key;
+ * verification is deterministic so they are embedded as fixtures.
+ */
+
+import { assertEquals } from "@std/assert";
+import { verifySignature } from "$lib/utils/security/cryptoUtils.ts";
+
+const MESSAGE = "Update creator name to Alice at 1700000000000";
+const P2TR = "bc1pr4zzasskelxqqqurj7pelzrcufrxl4kjqxn5zk0uaafkpt5ndtdq8t8w76";
+const P2WPKH = "bc1ql9y6eq0amutq8yhvuuhwrp68shg9r2979ecluw";
+const P2TR_BIP322_SIG =
+  "AUFxE/c+HJy8KIJI78VuvBAUWcsRPoX+cQZ+I7hX3Ask1iHGpmv6Tg9ytCva8hMKsLGAJWhMdij3DmL89Jzy1Q76AQ==";
+const P2WPKH_BIP322_SIG =
+  "AkcwRAIgYmvpu8cox1sRJVZ8gt8Hz5dWVnZh12Edq3oPUpVzqToCIDkcbD/W1Myb9t80hOHwcEXawzSaxseKTLj3tAP9ZRGVASECU0VpPw96QfHpm9Ns0/ilY74g/hMLzdjwzss85M5Hilc=";
+
+const originalConsoleError = console.error;
+
+function withQuietConsole(fn: () => void) {
+  console.error = () => {};
+  try {
+    fn();
+  } finally {
+    console.error = originalConsoleError;
+  }
+}
+
+Deno.test("verifySignature: accepts a BIP-322 signature from a P2TR (ordinals) address", () => {
+  assertEquals(verifySignature(MESSAGE, P2TR_BIP322_SIG, P2TR), true);
+});
+
+Deno.test("verifySignature: accepts a BIP-322 signature from a P2WPKH (payment) address", () => {
+  assertEquals(verifySignature(MESSAGE, P2WPKH_BIP322_SIG, P2WPKH), true);
+});
+
+Deno.test("verifySignature: P2TR signature does not verify against the sibling payment address", () => {
+  withQuietConsole(() => {
+    assertEquals(verifySignature(MESSAGE, P2TR_BIP322_SIG, P2WPKH), false);
+  });
+});
+
+Deno.test("verifySignature: payment signature does not verify against the sibling P2TR address", () => {
+  withQuietConsole(() => {
+    assertEquals(verifySignature(MESSAGE, P2WPKH_BIP322_SIG, P2TR), false);
+  });
+});
+
+Deno.test("verifySignature: P2TR signature rejects a tampered message", () => {
+  withQuietConsole(() => {
+    assertEquals(verifySignature(MESSAGE + "!", P2TR_BIP322_SIG, P2TR), false);
+  });
+});

--- a/tests/unit/openapiValidator.test.ts
+++ b/tests/unit/openapiValidator.test.ts
@@ -34,30 +34,44 @@ Deno.test("OpenAPI Validator", async (t) => {
   await t.step(
     "should validate SRC-20 response with v2.3 nested structure",
     async () => {
+      // /api/v2/src20/{op} (schema.yml) returns PaginatedSrc20ResponseBody:
+      // pagination fields + data[] of Src20Detail with the v2.3 nested
+      // mint_progress / market_data objects. Before that path was documented
+      // this step matched no schema and passed vacuously.
       const mockResponse = {
-        data: {
-          tick: "STAMP",
-          p: "src-20",
-          op: "deploy",
-          max: "1000000",
-          lim: "1000",
-          dec: "18",
-          market_data: {
-            price_usd: 0.5,
-            price_btc: 0.00001,
-            market_cap_usd: 500000,
+        page: 1,
+        limit: 50,
+        totalPages: 1,
+        total: 1,
+        last_block: 965984,
+        data: [
+          {
+            tx_hash: "abc123",
+            block_index: 100,
+            tick: "STAMP",
+            p: "SRC-20",
+            op: "DEPLOY",
+            max: "1000000",
+            lim: "1000",
+            deci: 18,
+            market_data: {
+              price_usd: "0.5",
+              price_btc: "0.00001",
+              market_cap_usd: "500000",
+            },
+            mint_progress: {
+              progress: "75.00",
+              current: "750000",
+              max: "1000000",
+              total_mints: 750,
+            },
           },
-          mint_progress: {
-            progress: 0.75,
-            current: 750000,
-            total_mints: 750,
-          },
-        },
+        ],
       };
 
       const result = await validateAgainstSchema(
         "GET",
-        "/api/v2/src20/STAMP",
+        "/api/v2/src20/deploy",
         200,
         mockResponse,
       );

--- a/tests/unit/routeResponseHelpers.test.ts
+++ b/tests/unit/routeResponseHelpers.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Route-level tests for the manual `new Response()` sites migrated to
+ * ApiResponseUtil / WebResponseUtil (issue #1223).
+ *
+ * Each test pins the status, content-type, cache headers and body that the
+ * route emitted BEFORE the migration so the helper-based version is proven
+ * equivalent on the wire.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { afterEach, describe, it } from "jsr:@std/testing@1.0.14/bdd";
+import { restore, stub } from "@std/testing@1.0.14/mock";
+
+import { handler as sitemapHandler } from "../../routes/sitemap.xml.ts";
+import { handleContentRequest } from "../../routes/handlers/sharedContentHandler.ts";
+import { handler as keysHandler } from "../../routes/api/v2/keys/index.ts";
+import { handler as apiMiddleware } from "../../routes/api/_middleware.ts";
+import { StampController } from "$server/controller/stampController.ts";
+import { ApiKeyService } from "$server/services/apiKey/apiKeyService.ts";
+import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
+
+const silence = () => {
+  const noop = () => {};
+  const saved = { error: console.error, warn: console.warn, log: console.log };
+  console.error = noop;
+  console.warn = noop;
+  console.log = noop;
+  return () => {
+    console.error = saved.error;
+    console.warn = saved.warn;
+    console.log = saved.log;
+  };
+};
+
+describe("routes/sitemap.xml.ts", () => {
+  it("returns XML with a 1h public cache on every cache layer", async () => {
+    const req = new Request("https://stampchain.io/sitemap.xml");
+    const res = await sitemapHandler.GET!(req, {} as never);
+
+    assertEquals(res.status, 200);
+    assertEquals(
+      res.headers.get("content-type"),
+      "application/xml; charset=utf-8",
+    );
+    assertEquals(res.headers.get("cache-control"), "public, max-age=3600");
+    assertEquals(res.headers.get("cdn-cache-control"), "public, max-age=3600");
+    assertEquals(
+      res.headers.get("cloudflare-cdn-cache-control"),
+      "public, max-age=3600",
+    );
+    assertEquals(res.headers.get("surrogate-control"), "max-age=3600");
+    assertEquals(res.headers.get("edge-control"), "cache-maxage=3600");
+    assertEquals(res.headers.get("x-api-version") !== null, true);
+
+    const body = await res.text();
+    assertStringIncludes(body, '<?xml version="1.0" encoding="UTF-8"?>');
+    assertStringIncludes(
+      body,
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    assertStringIncludes(body, "<loc>https://stampchain.io/</loc>");
+    assertStringIncludes(body, "<loc>https://stampchain.io/marketplace</loc>");
+  });
+});
+
+describe("routes/handlers/sharedContentHandler.ts", () => {
+  afterEach(() => restore());
+
+  it("re-emits direct 200 HTML with edge-cache headers and CF-safe Vary", async () => {
+    const txHash = "a".repeat(64);
+    const html = "<html><body>stamp</body></html>";
+    stub(
+      StampController,
+      "getStampFile",
+      () =>
+        Promise.resolve(
+          new Response(html, {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "vary": "Accept-Encoding, X-API-Version, Origin",
+              "cache-control": "public, max-age=31536000, immutable",
+              "x-frame-options": "DENY",
+              "x-custom-upstream": "kept",
+            },
+          }),
+        ),
+    );
+
+    const ctx = {
+      url: new URL(`https://stampchain.io/content/${txHash}`),
+      state: { baseUrl: "https://stampchain.io" },
+    } as never;
+    const res = await handleContentRequest(txHash, ctx);
+
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("content-type"), "text/html; charset=utf-8");
+    assertEquals(
+      res.headers.get("cache-control"),
+      "public, max-age=3600, no-transform",
+    );
+    assertEquals(res.headers.get("cdn-cache-control"), "public, max-age=86400");
+    // Vary must be exactly Accept-Encoding or Cloudflare skips edge caching.
+    assertEquals(res.headers.get("vary"), "Accept-Encoding");
+    assertEquals(res.headers.get("x-frame-options"), "SAMEORIGIN");
+    assertEquals(res.headers.get("x-content-type-options"), "nosniff");
+    // Upstream headers not overridden are preserved.
+    assertEquals(res.headers.get("x-custom-upstream"), "kept");
+    assertEquals(await res.text(), html);
+  });
+});
+
+describe("routes/api/v2/keys/index.ts", () => {
+  afterEach(() => restore());
+
+  const post = (email: string) =>
+    new Request("https://stampchain.io/api/v2/keys", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+
+  it("returns 409 DUPLICATE_EMAIL with no-store when the email already has a key", async () => {
+    const unsilence = silence();
+    try {
+      (globalThis as Record<string, unknown>).SKIP_REDIS_CONNECTION = true;
+      stub(
+        ApiKeyService,
+        "createKey",
+        () => Promise.reject(new Error("Duplicate entry 'x' for key 'email'")),
+      );
+
+      const res = await keysHandler.POST!(post("dupe@example.com"), {} as never);
+
+      assertEquals(res.status, 409);
+      assertEquals(res.headers.get("content-type"), "application/json");
+      assertEquals(res.headers.get("cache-control"), "no-store");
+      assertEquals(
+        await res.text(),
+        JSON.stringify({
+          error: "An API key already exists for this email address.",
+          code: "DUPLICATE_EMAIL",
+        }),
+      );
+    } finally {
+      unsilence();
+    }
+  });
+
+  it("signup rate-limit response keeps the 429 wire contract", async () => {
+    // The in-memory Redis fallback used under SKIP_REDIS_CONNECTION always
+    // returns incr=1, so the >3 branch is exercised through the exact helper
+    // call the route makes.
+    const res = ApiResponseUtil.custom(
+      {
+        error: "Too many signup attempts. Limit: 3 per hour per IP.",
+        retryAfter: 3600,
+      },
+      429,
+      {
+        forceNoCache: true,
+        headers: { "Retry-After": "3600", "Cache-Control": "no-store" },
+      },
+    );
+
+    assertEquals(res.status, 429);
+    assertEquals(res.headers.get("content-type"), "application/json");
+    assertEquals(res.headers.get("cache-control"), "no-store");
+    assertEquals(res.headers.get("retry-after"), "3600");
+    assertEquals(
+      await res.text(),
+      JSON.stringify({
+        error: "Too many signup attempts. Limit: 3 per hour per IP.",
+        retryAfter: 3600,
+      }),
+    );
+  });
+});
+
+describe("routes/api/_middleware.ts", () => {
+  it("maps a timeout to a 504 GATEWAY_TIMEOUT JSON body", async () => {
+    const unsilence = silence();
+    try {
+      const req = new Request("https://stampchain.io/api/v2/health");
+      const abort = new Error("aborted");
+      abort.name = "AbortError";
+      const ctx = {
+        state: {},
+        url: new URL(req.url),
+        next: () => Promise.reject(abort),
+      } as never;
+
+      const res = await apiMiddleware(req, ctx);
+
+      assertEquals(res.status, 504);
+      assertEquals(res.headers.get("content-type"), "application/json");
+      assertEquals(
+        await res.text(),
+        JSON.stringify({
+          status: "error",
+          message: "Request timeout - the operation took too long to complete",
+          error: "GATEWAY_TIMEOUT",
+        }),
+      );
+    } finally {
+      unsilence();
+    }
+  });
+});

--- a/tests/unit/routes/balanceAddressHandler.test.ts
+++ b/tests/unit/routes/balanceAddressHandler.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Handler-level regression test for GET /api/v2/balance/{address} (#1198,
+ * task 1217): the BTC leg is hard-capped at BTC_BALANCE_LEG_CEILING_MS so a
+ * slow third-party provider degrades the `btc` block (zeros + an
+ * `X-BTC-Balance-Status` header) instead of stalling the stamps + SRC-20
+ * data or producing a 5xx. The response schema is unchanged.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { handler } from "$routes/api/v2/balance/[address].ts";
+import { BTC_BALANCE_LEG_CEILING_MS } from "$lib/utils/data/processing/balanceUtils.ts";
+import { StampController } from "$server/controller/stampController.ts";
+import { Src20Controller } from "$server/controller/src20Controller.ts";
+
+/* ===== fixtures ===== */
+
+const STAMP_ROW = { cpid: "A1234567890123456789", quantity: 1 };
+const SRC20_ROW = { tick: "KEVIN", amt: "1000" };
+
+const STAMPS_RESULT = {
+  page: 1,
+  limit: 50,
+  totalPages: 1,
+  total: 1,
+  last_block: 900000,
+  data: [STAMP_ROW],
+};
+
+const SRC20_RESULT = {
+  page: 1,
+  limit: 50,
+  totalPages: 1,
+  total: 1,
+  last_block: 900001,
+  data: [SRC20_ROW],
+};
+
+function stubControllers() {
+  const stamps = stub(
+    StampController,
+    "getStampBalancesByAddress",
+    () =>
+      Promise.resolve(
+        STAMPS_RESULT as unknown as Awaited<
+          ReturnType<typeof StampController.getStampBalancesByAddress>
+        >,
+      ),
+  );
+  const src20 = stub(
+    Src20Controller,
+    "handleSrc20BalanceRequest",
+    () =>
+      Promise.resolve(
+        SRC20_RESULT as unknown as Awaited<
+          ReturnType<typeof Src20Controller.handleSrc20BalanceRequest>
+        >,
+      ),
+  );
+  return {
+    restore() {
+      stamps.restore();
+      src20.restore();
+    },
+  };
+}
+
+async function callHandler(address: string, query = "") {
+  const req = new Request(`http://localhost/api/v2/balance/${address}${query}`);
+  const ctx = { params: { address } } as unknown as Parameters<
+    NonNullable<typeof handler.GET>
+  >[1];
+  const started = Date.now();
+  const res = await handler.GET!(req, ctx);
+  const elapsed = Date.now() - started;
+  const body = await res.json();
+  return { res, body, elapsed };
+}
+
+// Distinct addresses per test: provider results are cached per address for 60s.
+const ADDR_SLOW = "bc1qzxszplp8v7w0jc89dlrqyct9staqlhwxzy7lkq";
+const ADDR_FAILING = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const ADDR_NORMAL = "bc1q20d2cdvy2x83h3ssrz5lgryy4c9wqxsgc749ej";
+
+const MEMPOOL_OK_BODY = {
+  address: ADDR_NORMAL,
+  chain_stats: {
+    funded_txo_count: 959,
+    funded_txo_sum: 13272991,
+    spent_txo_count: 944,
+    spent_txo_sum: 13257661,
+    tx_count: 981,
+  },
+  mempool_stats: {
+    funded_txo_count: 0,
+    funded_txo_sum: 0,
+    spent_txo_count: 0,
+    spent_txo_sum: 0,
+    tx_count: 0,
+  },
+};
+
+/* ===== (a) slow BTC leg does not delay the response beyond the ceiling ===== */
+
+Deno.test("balance/[address]: a BTC provider that never answers yields a degraded btc block within the ceiling", async () => {
+  const controllers = stubControllers();
+  // Worst case: upstream hangs AND ignores the abort signal.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => new Promise<Response>(() => {}),
+  );
+  try {
+    const { res, body, elapsed } = await callHandler(ADDR_SLOW);
+
+    assertEquals(res.status, 200); // never a 5xx for a slow third party
+    assert(
+      elapsed < BTC_BALANCE_LEG_CEILING_MS + 1000,
+      `expected < ${BTC_BALANCE_LEG_CEILING_MS + 1000}ms, took ${elapsed}ms`,
+    );
+    assertEquals(res.headers.get("X-BTC-Balance-Status"), "timeout");
+
+    // Stamps + SRC-20 data are served in full ...
+    assertEquals(body.data.stamps, [STAMP_ROW]);
+    assertEquals(body.data.src20, [SRC20_ROW]);
+    assertEquals(body.total, 2);
+    assertEquals(body.last_block, 900001);
+    // ... and the btc block keeps its shape, degraded to zeros.
+    assertEquals(body.btc, {
+      address: ADDR_SLOW,
+      balance: 0,
+      txCount: 0,
+      unconfirmedBalance: 0,
+      unconfirmedTxCount: 0,
+    });
+    // Existing informational headers are untouched.
+    assert(
+      res.headers.get("X-Preferred-Endpoints")?.includes(
+        "/api/v2/stamps/balance",
+      ),
+    );
+  } finally {
+    fetchStub.restore();
+    controllers.restore();
+  }
+});
+
+Deno.test("balance/[address]: providers answering 429 are retried only within budget and degrade to 'unavailable'", async () => {
+  const controllers = stubControllers();
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(new Response("rate limited", { status: 429 })),
+  );
+  try {
+    const { res, body, elapsed } = await callHandler(ADDR_FAILING);
+
+    assertEquals(res.status, 200);
+    assert(
+      elapsed < BTC_BALANCE_LEG_CEILING_MS,
+      `expected < ${BTC_BALANCE_LEG_CEILING_MS}ms, took ${elapsed}ms`,
+    );
+    assertEquals(res.headers.get("X-BTC-Balance-Status"), "unavailable");
+    // Pre-fix this path was 4 mempool attempts + 3 x 1s sleeps + BlockCypher.
+    assert(
+      fetchStub.calls.length <= 3,
+      `expected <= 3 provider calls, saw ${fetchStub.calls.length}`,
+    );
+    assertEquals(body.btc.balance, 0);
+    assertEquals(body.data.stamps, [STAMP_ROW]);
+  } finally {
+    fetchStub.restore();
+    controllers.restore();
+  }
+});
+
+/* ===== (b) normal path is unchanged ===== */
+
+Deno.test("balance/[address]: normal path returns the live btc balance with status 'ok'", async () => {
+  const controllers = stubControllers();
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(Response.json(MEMPOOL_OK_BODY)),
+  );
+  try {
+    const { res, body, elapsed } = await callHandler(
+      ADDR_NORMAL,
+      "?limit=50&page=1",
+    );
+
+    assertEquals(res.status, 200);
+    assert(elapsed < 1000, `expected < 1000ms, took ${elapsed}ms`);
+    assertEquals(res.headers.get("X-BTC-Balance-Status"), "ok");
+    assertEquals(fetchStub.calls.length, 1);
+
+    assertEquals(body.page, 1);
+    assertEquals(body.limit, 50);
+    assertEquals(body.total, 2);
+    assertEquals(body.totalPages, 1);
+    assertEquals(body.last_block, 900001);
+    assertEquals(body.btc, {
+      address: ADDR_NORMAL,
+      balance: 0.0001533,
+      txCount: 981,
+      unconfirmedBalance: 0,
+      unconfirmedTxCount: 0,
+    });
+    assertEquals(body.data.stamps, [STAMP_ROW]);
+    assertEquals(body.data.src20, [SRC20_ROW]);
+  } finally {
+    fetchStub.restore();
+    controllers.restore();
+  }
+});

--- a/tests/unit/utils/btcBalanceLegCeiling.test.ts
+++ b/tests/unit/utils/btcBalanceLegCeiling.test.ts
@@ -1,0 +1,296 @@
+import { assert, assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import {
+  fetchJsonWithTimeout,
+  getBTCBalanceFromMempool,
+} from "$lib/utils/mempool.ts";
+import {
+  BTC_BALANCE_LEG_CEILING_MS,
+  getBTCBalanceInfo,
+  getBTCBalanceInfoBounded,
+} from "$lib/utils/data/processing/balanceUtils.ts";
+
+// Regression coverage for #1198 / task 1217: the aggregate
+// /api/v2/balance/{address} endpoint still took 10-23s on a cold hit AFTER
+// #1206 bounded each individual provider fetch, because nothing bounded the
+// BTC leg as a whole: two sequential 5s deadlines (10s), plus the mempool
+// retry loop on non-timeout errors (4 x 5s + 3 x 1s back-off ~= 23s). The
+// provider chain now runs against ONE shared deadline, the body read is
+// covered by the same deadline, and the handler applies a hard ceiling.
+
+/* ===== fetch stubs ===== */
+
+/** Upstream that never answers but honours the abort signal (real Deno behaviour). */
+function hangUntilAbort() {
+  return stub(
+    globalThis,
+    "fetch",
+    (_input: string | URL | Request, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      }),
+  );
+}
+
+/** Upstream that never answers AND ignores the abort signal (worst case). */
+function hangForever() {
+  return stub(
+    globalThis,
+    "fetch",
+    () => new Promise<Response>(() => {}),
+  );
+}
+
+const MEMPOOL_OK_BODY = {
+  address: "x",
+  chain_stats: {
+    funded_txo_count: 959,
+    funded_txo_sum: 13272991,
+    spent_txo_count: 944,
+    spent_txo_sum: 13257661,
+    tx_count: 981,
+  },
+  mempool_stats: {
+    funded_txo_count: 0,
+    funded_txo_sum: 0,
+    spent_txo_count: 0,
+    spent_txo_sum: 0,
+    tx_count: 0,
+  },
+};
+
+function mempoolOk() {
+  return stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(Response.json(MEMPOOL_OK_BODY)),
+  );
+}
+
+// Distinct addresses per test: successful provider results are cached in
+// dbManager's in-memory fallback cache for 60s within this test process.
+const ADDR_RETRY_SHORT = "bc1qzxszplp8v7w0jc89dlrqyct9staqlhwxzy7lkq";
+const ADDR_RETRY_LONG = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const ADDR_BUDGET_SPLIT = "bc1q20d2cdvy2x83h3ssrz5lgryy4c9wqxsgc749ej";
+const ADDR_FALLBACK = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+const ADDR_NORMAL = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const ADDR_CEILING =
+  "bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9";
+const ADDR_UNAVAILABLE = "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy";
+const ADDR_BOUNDED_OK =
+  "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
+
+/* ===== fetchJsonWithTimeout: the deadline covers the body read ===== */
+
+Deno.test("fetchJsonWithTimeout times out a body that never finishes streaming", async () => {
+  // Headers arrive immediately; the body stalls. fetchWithTimeout disarmed its
+  // timer once headers arrived, leaving response.json() unbounded — this helper
+  // keeps the abort armed until the body is parsed.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    (_input: string | URL | Request, init?: RequestInit) => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          init?.signal?.addEventListener("abort", () => {
+            controller.error(new DOMException("aborted", "AbortError"));
+          });
+        },
+      });
+      return Promise.resolve(
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    },
+  );
+  try {
+    const started = Date.now();
+    let caught: unknown;
+    try {
+      await fetchJsonWithTimeout("https://example.com/", 50);
+    } catch (e) {
+      caught = e;
+    }
+    assert(caught instanceof Error, "expected an Error");
+    assertEquals(caught.name, "TimeoutError");
+    assert(Date.now() - started < 1000, "body read must be bounded");
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+/* ===== getBTCBalanceFromMempool: retries are bounded by the deadline ===== */
+
+Deno.test("getBTCBalanceFromMempool does not retry a 429 when the deadline leaves no room", async () => {
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(new Response("slow down", { status: 429 })),
+  );
+  try {
+    const started = Date.now();
+    const result = await getBTCBalanceFromMempool(
+      ADDR_RETRY_SHORT,
+      0,
+      Date.now() + 500, // < 1s retry back-off: no retry may be attempted
+    );
+    assertEquals(result, null);
+    assertEquals(fetchStub.calls.length, 1);
+    assert(Date.now() - started < 500, "must give up without sleeping");
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceFromMempool stops retrying once the deadline is spent", async () => {
+  // Before the fix a non-timeout error retried MAX_RETRIES (3) times with a
+  // 1s back-off regardless of any deadline: 4 attempts, >= 3s.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(new Response("upstream error", { status: 503 })),
+  );
+  try {
+    const started = Date.now();
+    const result = await getBTCBalanceFromMempool(
+      ADDR_RETRY_LONG,
+      0,
+      Date.now() + 1500,
+    );
+    const elapsed = Date.now() - started;
+    assertEquals(result, null);
+    assertEquals(fetchStub.calls.length, 2); // one retry fits, a second does not
+    assert(elapsed < 1500, `expected < 1500ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+/* ===== getBTCBalanceInfo: one shared budget across providers ===== */
+
+Deno.test("getBTCBalanceInfo bounds the WHOLE chain and still gives the fallback its share", async () => {
+  const fetchStub = hangUntilAbort();
+  try {
+    const started = Date.now();
+    const info = await getBTCBalanceInfo(ADDR_BUDGET_SPLIT, { timeoutMs: 400 });
+    const elapsed = Date.now() - started;
+    assertEquals(info, null);
+    // Both providers were tried (mempool did not starve BlockCypher) ...
+    assertEquals(fetchStub.calls.length, 2);
+    // ... and the total stayed inside the budget (was 2 x 5s before).
+    assert(elapsed < 1000, `expected < 1000ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfo hands a fast-failing provider's unused budget to the fallback", async () => {
+  let calls = 0;
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    (input: string | URL | Request) => {
+      calls++;
+      const url = String(input);
+      if (url.includes("blockcypher")) {
+        return Promise.resolve(
+          Response.json({
+            address: ADDR_FALLBACK,
+            balance: 15330,
+            unconfirmed_balance: 0,
+            n_tx: 981,
+            unconfirmed_n_tx: 0,
+          }),
+        );
+      }
+      return Promise.resolve(new Response("rate limited", { status: 429 }));
+    },
+  );
+  try {
+    const started = Date.now();
+    const info = await getBTCBalanceInfo(ADDR_FALLBACK, { timeoutMs: 600 });
+    const elapsed = Date.now() - started;
+    assert(info !== null, "BlockCypher fallback should have answered");
+    assertEquals(info.balance, 0.0001533);
+    assertEquals(info.txCount, 981);
+    assertEquals(calls, 2); // mempool once (no retry fits in its 300ms share), then BlockCypher
+    assert(elapsed < 600, `expected < 600ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfo normal path is unchanged: first provider answers, one fetch", async () => {
+  const fetchStub = mempoolOk();
+  try {
+    const info = await getBTCBalanceInfo(ADDR_NORMAL);
+    assert(info !== null);
+    assertEquals(info.address, ADDR_NORMAL);
+    assertEquals(info.balance, 0.0001533); // 15330 sats
+    assertEquals(info.txCount, 981);
+    assertEquals(info.unconfirmedBalance, 0);
+    assertEquals(info.unconfirmedTxCount, 0);
+    assertEquals(fetchStub.calls.length, 1);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+/* ===== getBTCBalanceInfoBounded: the handler-level ceiling ===== */
+
+Deno.test("BTC_BALANCE_LEG_CEILING_MS keeps the aggregate endpoint under the 5s regression threshold", () => {
+  assert(BTC_BALANCE_LEG_CEILING_MS > 0);
+  assert(BTC_BALANCE_LEG_CEILING_MS <= 3000);
+});
+
+Deno.test("getBTCBalanceInfoBounded resolves 'timeout' when the chain never returns", async () => {
+  // The upstream ignores the abort signal, so the chain can never finish on
+  // its own; only the outer ceiling can resolve this. The ceiling must leave
+  // the chain a real budget (ceiling - 200ms grace) — with a near-zero budget
+  // the chain would legitimately give up as 'unavailable' before it fires.
+  const fetchStub = hangForever();
+  try {
+    const started = Date.now();
+    const leg = await getBTCBalanceInfoBounded(ADDR_CEILING, 500);
+    const elapsed = Date.now() - started;
+    assertEquals(leg.status, "timeout");
+    assertEquals(leg.info, null);
+    assert(elapsed >= 450, `ceiling fired early: ${elapsed}ms`);
+    assert(elapsed < 1500, `expected < 1500ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfoBounded resolves 'unavailable' when providers fail inside the budget", async () => {
+  const fetchStub = hangUntilAbort();
+  try {
+    const started = Date.now();
+    const leg = await getBTCBalanceInfoBounded(ADDR_UNAVAILABLE, 2000, {
+      timeoutMs: 300,
+    });
+    const elapsed = Date.now() - started;
+    assertEquals(leg.status, "unavailable");
+    assertEquals(leg.info, null);
+    assert(elapsed < 2000, `expected < 2000ms, took ${elapsed}ms`);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+Deno.test("getBTCBalanceInfoBounded resolves 'ok' with the balance on the normal path", async () => {
+  const fetchStub = mempoolOk();
+  try {
+    const leg = await getBTCBalanceInfoBounded(ADDR_BOUNDED_OK, 1000);
+    assertEquals(leg.status, "ok");
+    assert(leg.info !== null);
+    assertEquals(leg.info.balance, 0.0001533);
+    assertEquals(leg.info.txCount, 981);
+  } finally {
+    fetchStub.restore();
+  }
+});

--- a/tests/unit/wallet/ownership.test.ts
+++ b/tests/unit/wallet/ownership.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for lib/utils/wallet/ownership.ts
+ *
+ * The helper is the single source of truth for "does the connected wallet
+ * control this address?". Dual-address wallets (Xverse) expose a payment
+ * address on `wallet.address` and an ordinals address on
+ * `wallet.ordinalsAddress`; both must be recognised as owned.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  addressesEqual,
+  getWalletAddresses,
+  walletOwnsAddress,
+} from "$lib/utils/wallet/ownership.ts";
+
+const PAYMENT = "bc1ql9y6eq0amutq8yhvuuhwrp68shg9r2979ecluw";
+const ORDINALS =
+  "bc1pr4zzasskelxqqqurj7pelzrcufrxl4kjqxn5zk0uaafkpt5ndtdq8t8w76";
+const OTHER = "bc1qpayment123abcdefghijklmnopqrstuvwxyz0123456";
+const LEGACY = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2";
+const LEGACY_RECASED = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVn2";
+
+const xverseWallet = {
+  address: PAYMENT,
+  ordinalsAddress: ORDINALS,
+  accounts: [PAYMENT, ORDINALS],
+};
+
+const singleAddressWallet = {
+  address: PAYMENT,
+  accounts: [PAYMENT],
+};
+
+// ============================================================================
+// walletOwnsAddress
+// ============================================================================
+
+Deno.test("walletOwnsAddress: matches the payment address", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, PAYMENT), true);
+  assertEquals(walletOwnsAddress(singleAddressWallet, PAYMENT), true);
+});
+
+Deno.test("walletOwnsAddress: matches the ordinals address (Xverse)", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, ORDINALS), true);
+});
+
+Deno.test("walletOwnsAddress: rejects an address the wallet does not control", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, OTHER), false);
+  assertEquals(walletOwnsAddress(singleAddressWallet, ORDINALS), false);
+});
+
+Deno.test("walletOwnsAddress: false for missing ordinalsAddress on single-address wallets", () => {
+  const wallet = { address: PAYMENT, accounts: [] as string[] };
+  assertEquals(walletOwnsAddress(wallet, PAYMENT), true);
+  assertEquals(walletOwnsAddress(wallet, ORDINALS), false);
+});
+
+Deno.test("walletOwnsAddress: false for null / undefined / disconnected wallet", () => {
+  assertEquals(walletOwnsAddress(null, PAYMENT), false);
+  assertEquals(walletOwnsAddress(undefined, PAYMENT), false);
+  assertEquals(walletOwnsAddress({}, PAYMENT), false);
+  assertEquals(
+    walletOwnsAddress({ address: "", accounts: [] }, PAYMENT),
+    false,
+  );
+  assertEquals(walletOwnsAddress({ address: "", accounts: [] }, ""), false);
+});
+
+Deno.test("walletOwnsAddress: false for empty / non-string target address", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, ""), false);
+  assertEquals(walletOwnsAddress(xverseWallet, "   "), false);
+  assertEquals(walletOwnsAddress(xverseWallet, undefined), false);
+  assertEquals(walletOwnsAddress(xverseWallet, null), false);
+  assertEquals(walletOwnsAddress(xverseWallet, 42), false);
+});
+
+Deno.test("walletOwnsAddress: an empty wallet address never matches an empty target", () => {
+  // Guards against "" === "" treating a disconnected wallet as owner.
+  assertEquals(walletOwnsAddress({ address: "" }, ""), false);
+});
+
+Deno.test("walletOwnsAddress: recognises addresses only present in accounts", () => {
+  const wallet = { address: PAYMENT, accounts: [PAYMENT, ORDINALS] };
+  assertEquals(walletOwnsAddress(wallet, ORDINALS), true);
+});
+
+Deno.test("walletOwnsAddress: ignores non-string entries in accounts", () => {
+  const wallet = {
+    address: PAYMENT,
+    accounts: [PAYMENT, undefined, null, 7] as unknown as string[],
+  };
+  assertEquals(walletOwnsAddress(wallet, PAYMENT), true);
+  assertEquals(walletOwnsAddress(wallet, "7"), false);
+});
+
+Deno.test("walletOwnsAddress: bech32 comparison is case-insensitive", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, PAYMENT.toUpperCase()), true);
+  assertEquals(walletOwnsAddress(xverseWallet, ORDINALS.toUpperCase()), true);
+  assertEquals(
+    walletOwnsAddress({ address: PAYMENT.toUpperCase() }, PAYMENT),
+    true,
+  );
+});
+
+Deno.test("walletOwnsAddress: base58 (legacy) comparison is case-sensitive", () => {
+  const legacyWallet = { address: LEGACY, accounts: [LEGACY] };
+  assertEquals(walletOwnsAddress(legacyWallet, LEGACY), true);
+  assertEquals(walletOwnsAddress(legacyWallet, LEGACY_RECASED), false);
+  assertEquals(walletOwnsAddress(legacyWallet, LEGACY.toLowerCase()), false);
+});
+
+Deno.test("walletOwnsAddress: surrounding whitespace is not significant", () => {
+  assertEquals(walletOwnsAddress(xverseWallet, `  ${ORDINALS}\n`), true);
+  assertEquals(walletOwnsAddress({ address: ` ${PAYMENT} ` }, PAYMENT), true);
+});
+
+// ============================================================================
+// getWalletAddresses
+// ============================================================================
+
+Deno.test("getWalletAddresses: returns payment first, then ordinals, deduplicated", () => {
+  assertEquals(getWalletAddresses(xverseWallet), [PAYMENT, ORDINALS]);
+});
+
+Deno.test("getWalletAddresses: single-address wallet yields one entry", () => {
+  assertEquals(getWalletAddresses(singleAddressWallet), [PAYMENT]);
+});
+
+Deno.test("getWalletAddresses: drops empty strings and non-strings", () => {
+  const wallet = {
+    address: "",
+    ordinalsAddress: ORDINALS,
+    accounts: ["", " ", ORDINALS, 5 as unknown as string],
+  };
+  assertEquals(getWalletAddresses(wallet), [ORDINALS]);
+});
+
+Deno.test("getWalletAddresses: dedupes bech32 case variants", () => {
+  const wallet = { address: PAYMENT, accounts: [PAYMENT.toUpperCase()] };
+  assertEquals(getWalletAddresses(wallet), [PAYMENT]);
+});
+
+Deno.test("getWalletAddresses: empty for null / undefined / empty wallet", () => {
+  assertEquals(getWalletAddresses(null), []);
+  assertEquals(getWalletAddresses(undefined), []);
+  assertEquals(getWalletAddresses({}), []);
+});
+
+// ============================================================================
+// addressesEqual
+// ============================================================================
+
+Deno.test("addressesEqual: exact match", () => {
+  assertEquals(addressesEqual(PAYMENT, PAYMENT), true);
+  assertEquals(addressesEqual(LEGACY, LEGACY), true);
+});
+
+Deno.test("addressesEqual: bech32 case-insensitive, base58 case-sensitive", () => {
+  assertEquals(addressesEqual(PAYMENT, PAYMENT.toUpperCase()), true);
+  assertEquals(addressesEqual("tb1qabc", "TB1QABC"), true);
+  assertEquals(addressesEqual(LEGACY, LEGACY_RECASED), false);
+});
+
+Deno.test("addressesEqual: different addresses and invalid inputs are not equal", () => {
+  assertEquals(addressesEqual(PAYMENT, ORDINALS), false);
+  assertEquals(addressesEqual(PAYMENT, ""), false);
+  assertEquals(addressesEqual("", ""), false);
+  assertEquals(addressesEqual(undefined, undefined), false);
+  assertEquals(addressesEqual(null, PAYMENT), false);
+  assertEquals(addressesEqual(1, 1), false);
+});

--- a/tests/unit/wallet/xverseSigning.test.ts
+++ b/tests/unit/wallet/xverseSigning.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for client/wallet/xverseSigning.ts — selection of the signing
+ * address and protocol used by Xverse `signMessage()`.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  resolveXverseSigningAddress,
+  xverseSigningProtocolFor,
+} from "$client/wallet/xverseSigning.ts";
+
+const PAYMENT = "bc1ql9y6eq0amutq8yhvuuhwrp68shg9r2979ecluw";
+const ORDINALS =
+  "bc1pr4zzasskelxqqqurj7pelzrcufrxl4kjqxn5zk0uaafkpt5ndtdq8t8w76";
+const FOREIGN =
+  "bc1pforeign0000000000000000000000000000000000000000000000000000";
+
+const wallet = {
+  address: PAYMENT,
+  ordinalsAddress: ORDINALS,
+  accounts: [PAYMENT, ORDINALS],
+};
+
+Deno.test("resolveXverseSigningAddress: defaults to the payment address", () => {
+  assertEquals(resolveXverseSigningAddress(wallet), PAYMENT);
+  assertEquals(resolveXverseSigningAddress(wallet, undefined), PAYMENT);
+});
+
+Deno.test("resolveXverseSigningAddress: allows the payment address explicitly", () => {
+  assertEquals(resolveXverseSigningAddress(wallet, PAYMENT), PAYMENT);
+});
+
+Deno.test("resolveXverseSigningAddress: allows the ordinals address", () => {
+  assertEquals(resolveXverseSigningAddress(wallet, ORDINALS), ORDINALS);
+});
+
+Deno.test("resolveXverseSigningAddress: rejects an address the wallet does not control", () => {
+  assertThrows(
+    () => resolveXverseSigningAddress(wallet, FOREIGN),
+    Error,
+    "not controlled by the connected Xverse wallet",
+  );
+  assertThrows(
+    () => resolveXverseSigningAddress(wallet, ""),
+    Error,
+    "not controlled by the connected Xverse wallet",
+  );
+});
+
+Deno.test("resolveXverseSigningAddress: rejects ordinals address on a wallet without one", () => {
+  const single = { address: PAYMENT, accounts: [PAYMENT] };
+  assertThrows(() => resolveXverseSigningAddress(single, ORDINALS), Error);
+});
+
+Deno.test("xverseSigningProtocolFor: ECDSA for the payment (P2WPKH) address", () => {
+  assertEquals(xverseSigningProtocolFor(PAYMENT), "ECDSA");
+  assertEquals(
+    xverseSigningProtocolFor("3P14159f73E4gFr7JterCCQh9QjiTjiZrG"),
+    "ECDSA",
+  );
+});
+
+Deno.test("xverseSigningProtocolFor: BIP322 for taproot (P2TR) addresses", () => {
+  assertEquals(xverseSigningProtocolFor(ORDINALS), "BIP322");
+  assertEquals(xverseSigningProtocolFor(ORDINALS.toUpperCase()), "BIP322");
+  assertEquals(xverseSigningProtocolFor("tb1p" + "q".repeat(58)), "BIP322");
+});

--- a/tests/unit/webResponseUtil.test.ts
+++ b/tests/unit/webResponseUtil.test.ts
@@ -243,3 +243,77 @@ Deno.test("WebResponseUtil - cache headers with routeType", () => {
   assertExists(response.headers.get("Cache-Control"));
   assertExists(response.headers.get("Vary"));
 });
+
+Deno.test("WebResponseUtil - modifiedResponse overrides upstream headers case-insensitively", async () => {
+  const upstream = new Response("old", {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "vary": "Accept-Encoding, X-API-Version, Origin",
+      "cache-control": "public, max-age=31536000, immutable",
+      "x-upstream": "kept",
+    },
+  });
+
+  const response = WebResponseUtil.modifiedResponse("new", upstream, {
+    headers: {
+      "Cache-Control": "public, max-age=3600, no-transform",
+      "Vary": "Accept-Encoding",
+    },
+  });
+
+  assertEquals(response.status, 200);
+  assertEquals(await response.text(), "new");
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=3600, no-transform",
+  );
+  assertEquals(response.headers.get("x-upstream"), "kept");
+  // Default normalisation still appends the API-version vary keys.
+  assertEquals(
+    response.headers.get("vary"),
+    "Accept-Encoding, X-API-Version, Origin",
+  );
+});
+
+Deno.test("WebResponseUtil - modifiedResponse immutableBinary keeps Vary CDN-safe", () => {
+  const upstream = new Response("x", {
+    headers: { "vary": "Accept-Encoding, X-API-Version, Origin" },
+  });
+
+  const response = WebResponseUtil.modifiedResponse("y", upstream, {
+    headers: { "Vary": "Accept-Encoding" },
+    immutableBinary: true,
+  });
+
+  assertEquals(response.headers.get("vary"), "Accept-Encoding");
+});
+
+Deno.test("WebResponseUtil - xmlResponse sets XML content type and honours cache overrides", async () => {
+  const xml = '<?xml version="1.0"?><root/>';
+  const response = WebResponseUtil.xmlResponse(xml, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "CDN-Cache-Control": "public, max-age=3600",
+    },
+  });
+
+  assertEquals(response.status, 200);
+  assertEquals(
+    response.headers.get("content-type"),
+    "application/xml; charset=utf-8",
+  );
+  assertEquals(response.headers.get("cache-control"), "public, max-age=3600");
+  assertEquals(
+    response.headers.get("cdn-cache-control"),
+    "public, max-age=3600",
+  );
+  assertExists(response.headers.get("x-api-version"));
+  assertExists(response.headers.get("content-security-policy"));
+  assertEquals(await response.text(), xml);
+});
+
+Deno.test("WebResponseUtil - xmlResponse defaults to security-header cache policy", () => {
+  const response = WebResponseUtil.xmlResponse("<a/>", { forceNoCache: true });
+  assertEquals(response.headers.get("cache-control"), "no-store, must-revalidate");
+});


### PR DESCRIPTION
Promotes five squash commits from `dev` to `main`, triggering the production deploy.

| commit | what |
|---|---|
| `2576b235b` | **#1246** `/api/v2/balance/{address}`: the BTC provider chain now runs against one shared deadline with a 3 s handler ceiling; degraded `btc` block is zeroed and flagged via `X-BTC-Balance-Status: ok\|unavailable\|timeout`. Root cause of the 10–23 s cold hits (#1198): retries on 429/5xx and an unbounded body read stacked beyond the #1206 per-fetch timeout. Schema unchanged. |
| `41cb4e37b` | **#1244** owner checks go through one `walletOwnsAddress` helper so Xverse ordinals (`bc1p…`) profiles show owner UI; Edit Creator Name signs with and submits the profile address (was always the payment address). Server verification unchanged. |
| `1ed252843` | **#1243** last five manual `Response()` sites moved to the response helpers; `deno task check:responses` is green. Migrated responses gain the standard helper headers; status, content-type, cache headers and bodies unchanged. |
| `e92da106c` | **#1245** `schema.yml` documents 18 previously undocumented `/api/v2` routes; validator ignore-list entries for the compose endpoints removed. |
| `55a7b3e5a` | **#1242** daily regression workflow keeps one rolling issue and auto-closes it on the next passing run (needs to be on `main` to affect the scheduled run). |

## Validation on the merged `dev` tree (`e92da106c`)
- `deno task check` (fmt, lint, type-check): clean; `deno task check:responses`: clean
- `deno task test:unit`: see the final run below (recorded at PR-open time)
- Every PR above went through CI green on its final head (incl. Lighthouse and both Newman suites) and had its gates rerun locally by the reviewer before merge.

## Runtime-behaviour notes for the deploy
- Balance endpoint worst case drops from ~23 s to ~3.4 s; watch `X-BTC-Balance-Status` in the daily regression artifacts to confirm the production trigger (mempool.space rate limiting is the inferred cause). BlockCypher's unauthenticated rate limit is tight, so `unavailable` may show up under a long mempool.space degradation.
- Xverse BIP-322 signing of the ordinals address (#1244) has not been exercised against a live extension; failure mode is the existing "Signing failed" toast with nothing written.
- No env, secret, task-definition, or DB schema changes.

## Before merging
- Rollback target: register a digest-pinned task-definition revision (the workflow's own rollback only reverts config). Current image is the one deployed by #1241 (task def `:145`).
- Expect the usual ~5 min mixed HTML/JS window while the old target drains.