### PR TITLE
fix(responses): stop dropping security/cache headers on stamp content (task 1230)

### DIFF
--- a/lib/utils/api/responses/webResponseUtil.ts
+++ b/lib/utils/api/responses/webResponseUtil.ts
@@ -347,5 +347,4 @@ export class WebResponseUtil {
       ),
     });
   }
-
 }

--- a/lib/utils/api/responses/webResponseUtil.ts
+++ b/lib/utils/api/responses/webResponseUtil.ts
@@ -74,12 +74,14 @@ export class WebResponseUtil {
     mimeType: string,
     options: StampResponseOptions = {},
   ): Response {
-    const baseHeaders = this.getContentTypeHeaders(mimeType, options);
-    const headers = new Headers({
-      ...baseHeaders,
-      ...options.headers,
-      "X-API-Version": API_RESPONSE_VERSION,
-    });
+    // Merge through a Headers object (never spread a Headers instance — it
+    // has no own enumerable properties, so `{ ...headers }` is `{}`).
+    // Caller-supplied headers override the stamp-content defaults.
+    const headers = new Headers(getStampContentHeaders(mimeType, options));
+    for (const [key, value] of Object.entries(options.headers || {})) {
+      headers.set(key, value);
+    }
+    headers.set("X-API-Version", API_RESPONSE_VERSION);
 
     // Binary content handling
     if (options.binary && content) {
@@ -90,16 +92,10 @@ export class WebResponseUtil {
           bytes[i] = binaryString.charCodeAt(i);
         }
 
+        headers.set("Vary", "Accept-Encoding, X-API-Version, Origin");
+        headers.set("Content-Length", bytes.length.toString());
         return new Response(bytes, {
-          headers: normalizeHeaders(
-            new Headers({
-              ...headers,
-              ...getBinaryContentHeaders(mimeType, options),
-              "X-API-Version": API_RESPONSE_VERSION,
-              "Vary": "Accept-Encoding, X-API-Version, Origin",
-              "Content-Length": bytes.length.toString(),
-            }),
-          ),
+          headers: normalizeHeaders(headers),
         });
       } catch (error) {
         console.error("Failed to convert base64 to binary:", error);
@@ -114,15 +110,10 @@ export class WebResponseUtil {
       mimeType.includes("xml");
 
     if (isTextBased) {
+      headers.set("Vary", "Accept-Encoding, X-API-Version, Origin");
+      headers.set("Content-Type", `${mimeType}; charset=utf-8`);
       return new Response(content, {
-        headers: normalizeHeaders(
-          new Headers({
-            ...headers,
-            "X-API-Version": API_RESPONSE_VERSION,
-            "Vary": "Accept-Encoding, X-API-Version, Origin",
-            "Content-Type": `${mimeType}; charset=utf-8`,
-          }),
-        ),
+        headers: normalizeHeaders(headers),
       });
     }
 

--- a/lib/utils/api/responses/webResponseUtil.ts
+++ b/lib/utils/api/responses/webResponseUtil.ts
@@ -348,46 +348,4 @@ export class WebResponseUtil {
     });
   }
 
-  private static getContentTypeHeaders(
-    mimeType: string,
-    options: StampResponseOptions,
-  ): HeadersInit {
-    if (mimeType.includes("html")) {
-      return {
-        ...getHtmlHeaders(options),
-        "Content-Type": `${mimeType}; charset=utf-8`,
-      };
-    }
-
-    if (mimeType.includes("javascript")) {
-      return {
-        ...getRecursiveHeaders(options),
-        "Content-Type": `${mimeType}; charset=utf-8`,
-      };
-    }
-
-    if (mimeType.includes("image/")) {
-      return {
-        ...getSecurityHeaders(options),
-        "Content-Type": mimeType,
-        "Cache-Control": "public, max-age=31536000, immutable",
-      };
-    }
-
-    if (
-      mimeType.includes("text/") ||
-      mimeType.includes("application/json") ||
-      mimeType.includes("xml")
-    ) {
-      return {
-        ...getSecurityHeaders(options),
-        "Content-Type": `${mimeType}; charset=utf-8`,
-      };
-    }
-
-    return {
-      ...getSecurityHeaders(options),
-      "Content-Type": mimeType,
-    };
-  }
 }

--- a/lib/utils/api/responses/webResponseUtil.ts
+++ b/lib/utils/api/responses/webResponseUtil.ts
@@ -1,8 +1,8 @@
 import {
   getBinaryContentHeaders,
   getHtmlHeaders,
-  getRecursiveHeaders,
   getSecurityHeaders,
+  getStampContentHeaders,
 } from "$lib/utils/security/securityHeaders.ts";
 import { normalizeHeaders } from "$lib/utils/api/headers/headerUtils.ts";
 import {

--- a/lib/utils/security/securityHeaders.ts
+++ b/lib/utils/security/securityHeaders.ts
@@ -1,5 +1,3 @@
-import { normalizeHeaders } from "$lib/utils/api/headers/headerUtils.ts";
-
 // Cache for security headers to improve performance
 const securityHeaderCache = new Map<string, Record<string, string>>();
 
@@ -125,23 +123,87 @@ export const getSecurityHeaders = (
   // Cache the headers for future use
   securityHeaderCache.set(cacheKey, headers);
 
-  return headers;
+  return { ...headers }; // first call must not hand out the cached object
 };
 
-export const getHtmlHeaders = (options?: { forceNoCache?: boolean }) =>
-  normalizeHeaders({
-    ...getSecurityHeaders({ ...options, context: "web" }),
-    "Content-Type": "text/html; charset=utf-8",
-  });
+/**
+ * Plain-record header producers.
+ *
+ * These MUST return plain objects, never `Headers` instances: every consumer
+ * merges them with object spread (`{ ...getHtmlHeaders(), ... }`), and a
+ * `Headers` instance has no own enumerable properties, so spreading one
+ * silently yields `{}` and drops every header it was meant to contribute.
+ * `normalizeHeaders` is applied once, by the response helper, at
+ * `new Response(...)` time.
+ */
+export const getHtmlHeaders = (
+  options?: { forceNoCache?: boolean },
+): Record<string, string> => ({
+  ...getSecurityHeaders({ ...options, context: "web" }),
+  "Content-Type": "text/html; charset=utf-8",
+});
 
-export const getRecursiveHeaders = (options?: { forceNoCache?: boolean }) =>
-  normalizeHeaders(getSecurityHeaders({ ...options, context: "recursive" }));
+export const getRecursiveHeaders = (
+  options?: { forceNoCache?: boolean },
+): Record<string, string> =>
+  getSecurityHeaders({ ...options, context: "recursive" });
 
 export const getBinaryContentHeaders = (
   mimeType: string,
   options?: { forceNoCache?: boolean },
-) =>
-  normalizeHeaders({
-    ...getSecurityHeaders({ ...options, context: "recursive" }),
+): Record<string, string> => ({
+  ...getSecurityHeaders({ ...options, context: "recursive" }),
+  "Content-Type": mimeType,
+});
+
+/**
+ * CSP for user-generated HTML stamp content served from `/content/` and `/s/`.
+ *
+ * Stamp HTML is fully author-controlled and is served from the site origin,
+ * so no source-list directive can constrain it without breaking real stamps:
+ * the on-chain corpus uses inline `<script>`/`<style>`/`on*=` handlers,
+ * `blob:` workers, `localStorage`, and loads scripts, images and iframes
+ * from arbitrary hosts (ordinals.com, arweave.net, cdn.jsdelivr.net,
+ * *.vercel.app, ...). The site "web" policy from `getSecurityHeaders` would
+ * block several of those, and CSP `sandbox` would change origin semantics
+ * (localStorage, same-origin fetch) for every stamp.
+ *
+ * The one directive that is both enforceable and already the live behaviour
+ * is embedding: `frame-ancestors 'self'` mirrors the `X-Frame-Options:
+ * SAMEORIGIN` that `/content/` and `/s/` HTML responses already send, and
+ * CSP3 gives `frame-ancestors` precedence when both are present, so the two
+ * agree. Resource loading is deliberately left unrestricted. Isolating stamp
+ * content on its own origin (or a `sandbox` policy) is a separate decision.
+ */
+export const STAMP_CONTENT_CSP = "frame-ancestors 'self'";
+
+/**
+ * Headers for stamp content (any MIME type) served by `WebResponseUtil.stampResponse`.
+ *
+ * Stamp content is immutable once inscribed, so the browser cache policy is
+ * the long-lived immutable one unless `forceNoCache` is set. Callers that
+ * need a different edge policy (e.g. the HTML paths in
+ * `routes/handlers/sharedContentHandler.ts`) override `Cache-Control` /
+ * `CDN-Cache-Control` explicitly. HTML additionally gets the embedding
+ * policy above plus `nosniff`; non-HTML types get no CSP so that SVG/JS
+ * stamps keep their current unrestricted behaviour (extending
+ * `frame-ancestors` to SVG documents would newly block third-party
+ * `<iframe>`/`<object>` embeds and is out of scope here).
+ */
+export const getStampContentHeaders = (
+  mimeType: string,
+  options: { forceNoCache?: boolean } = {},
+): Record<string, string> => {
+  const headers: Record<string, string> = {
     "Content-Type": mimeType,
-  });
+    "Cache-Control": options.forceNoCache
+      ? "no-store, must-revalidate"
+      : "public, max-age=31536000, immutable",
+  };
+  if (mimeType.toLowerCase().includes("html")) {
+    headers["Content-Security-Policy"] = STAMP_CONTENT_CSP;
+    headers["X-Frame-Options"] = "SAMEORIGIN";
+    headers["X-Content-Type-Options"] = "nosniff";
+  }
+  return { ...headers }; // first call must not hand out the cached object
+};

--- a/routes/handlers/sharedContentHandler.ts
+++ b/routes/handlers/sharedContentHandler.ts
@@ -3,7 +3,7 @@ import { getIdentifierType } from "$lib/utils/data/identifiers/identifierUtils.t
 import { isCpid, isTxHash } from "$lib/utils/typeGuards.ts";
 import { logger } from "$lib/utils/logger.ts";
 import { cleanHtmlForRendering } from "$lib/utils/ui/rendering/htmlCleanup.ts";
-import { getRecursiveHeaders } from "$lib/utils/security/securityHeaders.ts";
+import { getStampContentHeaders } from "$lib/utils/security/securityHeaders.ts";
 import { WebResponseUtil } from "$lib/utils/api/responses/webResponseUtil.ts";
 import { StampController } from "$server/controller/stampController.ts";
 import { RouteType } from "$server/services/infrastructure/cacheService.ts";
@@ -75,11 +75,11 @@ export async function handleContentRequest(
             const rawHtml = await contentResponse.text();
             const htmlContent = cleanHtmlForRendering(rawHtml);
 
-            // Use the standardized HTML response method with headers to prevent CDN modifications
-            const recursiveHeaders = getRecursiveHeaders();
+            // Stamp-content headers (CSP frame-ancestors, nosniff) plus explicit
+            // edge-cache / CDN-transform overrides.
             return WebResponseUtil.htmlResponse(htmlContent, {
               headers: {
-                ...Object.fromEntries(recursiveHeaders),
+                ...getStampContentHeaders("text/html"),
                 // Allow Cloudflare CDN to cache stamp content at the edge.
                 // Stamp data is immutable — once inscribed it never changes.
                 // Edge caching is critical for recursive stamps where the CF

--- a/scripts/check-manual-responses.ts
+++ b/scripts/check-manual-responses.ts
@@ -20,7 +20,6 @@ const EXCEPTIONS = [
   // These files are allowed to have manual Response() for specific reasons
   "routes/test/",
   "routes/_middleware.ts", // Complex middleware with custom headers
-  "routes/api/_middleware.ts", // API middleware with transformation
   "routes/api/v2/stamp/[stamp]/preview.ts", // Binary image processing with specialized headers
 ];
 

--- a/tests/unit/securityHeaders.test.ts
+++ b/tests/unit/securityHeaders.test.ts
@@ -1,0 +1,105 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  getBinaryContentHeaders,
+  getHtmlHeaders,
+  getRecursiveHeaders,
+  getSecurityHeaders,
+  getStampContentHeaders,
+  STAMP_CONTENT_CSP,
+} from "$lib/utils/security/securityHeaders.ts";
+
+// Every producer is consumed via object spread. A `Headers` instance has no own
+// enumerable properties, so spreading one yields {} and drops everything — the
+// exact regression that hid the security headers on stamp content (task 1230).
+function assertPlainRecord(name: string, value: unknown) {
+  assertEquals(value instanceof Headers, false, `${name} returned Headers`);
+  assertEquals(
+    Object.keys(value as object).length > 0,
+    true,
+    `${name} has no own enumerable keys`,
+  );
+  assertEquals(
+    Object.keys({ ...(value as object) }).length,
+    Object.keys(value as object).length,
+    `${name} loses keys when spread`,
+  );
+}
+
+Deno.test("securityHeaders - producers return spreadable plain records", () => {
+  assertPlainRecord("getSecurityHeaders", getSecurityHeaders());
+  assertPlainRecord("getHtmlHeaders", getHtmlHeaders());
+  assertPlainRecord("getRecursiveHeaders", getRecursiveHeaders());
+  assertPlainRecord(
+    "getBinaryContentHeaders",
+    getBinaryContentHeaders("image/png"),
+  );
+  assertPlainRecord(
+    "getStampContentHeaders",
+    getStampContentHeaders("text/html"),
+  );
+});
+
+Deno.test("securityHeaders - getHtmlHeaders = web policy + html content type", () => {
+  const headers = getHtmlHeaders();
+  assertEquals(headers["Content-Type"], "text/html; charset=utf-8");
+  assertEquals(
+    headers["Content-Security-Policy"],
+    getSecurityHeaders({ context: "web" })["Content-Security-Policy"],
+  );
+  assertEquals(
+    getHtmlHeaders({ forceNoCache: true })["Cache-Control"],
+    "no-store, must-revalidate",
+  );
+});
+
+Deno.test("securityHeaders - getRecursiveHeaders / getBinaryContentHeaders use the recursive policy", () => {
+  const recursive = getRecursiveHeaders();
+  assertEquals(recursive["Cross-Origin-Resource-Policy"], "cross-origin");
+  assertEquals(
+    recursive["Content-Security-Policy"].includes("frame-ancestors *"),
+    true,
+  );
+
+  const binary = getBinaryContentHeaders("image/gif");
+  assertEquals(binary["Content-Type"], "image/gif");
+  assertEquals(
+    binary["Content-Security-Policy"],
+    recursive["Content-Security-Policy"],
+  );
+});
+
+Deno.test("securityHeaders - getStampContentHeaders(html) = embedding policy only", () => {
+  const headers = getStampContentHeaders("text/html");
+  assertEquals(headers, {
+    "Content-Type": "text/html",
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "Content-Security-Policy": STAMP_CONTENT_CSP,
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-Content-Type-Options": "nosniff",
+  });
+  assertEquals(STAMP_CONTENT_CSP, "frame-ancestors 'self'");
+});
+
+Deno.test("securityHeaders - getStampContentHeaders(non-html) has no CSP", () => {
+  for (const mime of ["image/svg+xml", "application/javascript", "image/png"]) {
+    const headers = getStampContentHeaders(mime);
+    assertEquals(headers, {
+      "Content-Type": mime,
+      "Cache-Control": "public, max-age=31536000, immutable",
+    });
+  }
+  assertEquals(
+    getStampContentHeaders("image/png", { forceNoCache: true })[
+      "Cache-Control"
+    ],
+    "no-store, must-revalidate",
+  );
+});
+
+Deno.test("securityHeaders - getSecurityHeaders returns a fresh copy per call", () => {
+  const first = getSecurityHeaders({ context: "api" });
+  first["Cache-Control"] = "mutated";
+  const second = getSecurityHeaders({ context: "api" });
+  assertExists(second["Cache-Control"]);
+  assertEquals(second["Cache-Control"] === "mutated", false);
+});

--- a/tests/unit/webResponseUtil.test.ts
+++ b/tests/unit/webResponseUtil.test.ts
@@ -189,8 +189,11 @@ Deno.test("WebResponseUtil - stampResponse with binary image", async () => {
     binary: true,
   });
 
-  // Content-Type header is lost during normalization for binary responses
-  assertEquals(response.headers.get("Content-Type"), null);
+  assertEquals(response.headers.get("Content-Type"), "image/png");
+  assertEquals(
+    response.headers.get("Cache-Control"),
+    "public, max-age=31536000, immutable",
+  );
   assertExists(response.headers.get("Content-Length"));
 
   const body = await response.arrayBuffer();
@@ -315,5 +318,230 @@ Deno.test("WebResponseUtil - xmlResponse sets XML content type and honours cache
 
 Deno.test("WebResponseUtil - xmlResponse defaults to security-header cache policy", () => {
   const response = WebResponseUtil.xmlResponse("<a/>", { forceNoCache: true });
-  assertEquals(response.headers.get("cache-control"), "no-store, must-revalidate");
+  assertEquals(
+    response.headers.get("cache-control"),
+    "no-store, must-revalidate",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Full header-set assertions. The header producers in securityHeaders.ts used
+// to return Headers instances; spreading one into an object literal yields {}
+// and silently dropped every security/cache header (task 1230). These tests
+// pin the complete set so a regression cannot hide behind assertExists.
+// ---------------------------------------------------------------------------
+
+function headerNames(response: Response): string[] {
+  return [...response.headers.keys()].sort();
+}
+
+Deno.test("WebResponseUtil - htmlResponse emits the full web security header set", () => {
+  const response = WebResponseUtil.htmlResponse("<p>x</p>");
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cdn-cache-control",
+    "cloudflare-cdn-cache-control",
+    "content-security-policy",
+    "content-type",
+    "edge-control",
+    "surrogate-control",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
+  const csp = response.headers.get("content-security-policy") ?? "";
+  assertEquals(csp.includes("frame-ancestors 'self'"), true);
+  assertEquals(csp.includes("script-src"), true);
+});
+
+Deno.test("WebResponseUtil - htmlResponse forceNoCache + caller overrides", () => {
+  const response = WebResponseUtil.htmlResponse("<p>x</p>", {
+    forceNoCache: true,
+    headers: { "X-Frame-Options": "SAMEORIGIN", "Vary": "Accept-Encoding" },
+  });
+
+  assertEquals(
+    response.headers.get("cache-control"),
+    "no-store, must-revalidate",
+  );
+  assertEquals(response.headers.get("x-frame-options"), "SAMEORIGIN");
+  assertExists(response.headers.get("content-security-policy"));
+});
+
+Deno.test("WebResponseUtil - stampResponse(text/html) emits the stamp-content header set", () => {
+  const response = WebResponseUtil.stampResponse("<p>x</p>", "text/html", {
+    binary: false,
+  });
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "content-security-policy",
+    "content-type",
+    "vary",
+    "x-api-version",
+    "x-content-type-options",
+    "x-frame-options",
+  ]);
+  assertEquals(
+    response.headers.get("content-security-policy"),
+    "frame-ancestors 'self'",
+  );
+  assertEquals(response.headers.get("x-frame-options"), "SAMEORIGIN");
+  assertEquals(response.headers.get("x-content-type-options"), "nosniff");
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
+  assertEquals(
+    response.headers.get("vary"),
+    "Accept-Encoding, X-API-Version, Origin",
+  );
+});
+
+Deno.test("WebResponseUtil - stampResponse(text/html) never carries the site web CSP", () => {
+  const response = WebResponseUtil.stampResponse("<p>x</p>", "text/html", {
+    binary: false,
+  });
+  const csp = response.headers.get("content-security-policy") ?? "";
+  // Real HTML stamps load scripts/iframes/images from arbitrary hosts and use
+  // blob: workers; a source-list CSP would break them.
+  assertEquals(csp.includes("script-src"), false);
+  assertEquals(csp.includes("default-src"), false);
+  assertEquals(csp.includes("connect-src"), false);
+});
+
+Deno.test("WebResponseUtil - stampResponse caller headers override defaults", () => {
+  const response = WebResponseUtil.stampResponse("<p>x</p>", "text/html", {
+    binary: false,
+    headers: {
+      "Cache-Control": "public, max-age=3600, no-transform",
+      "CDN-Cache-Control": "public, max-age=86400",
+      "CF-No-Transform": "true",
+    },
+  });
+
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=3600, no-transform",
+  );
+  assertEquals(
+    response.headers.get("cdn-cache-control"),
+    "public, max-age=86400",
+  );
+  assertEquals(response.headers.get("cf-no-transform"), "true");
+  // Forced trailing headers still win over caller values.
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+});
+
+Deno.test("WebResponseUtil - stampResponse(image/svg+xml) has cache headers and no CSP", () => {
+  const response = WebResponseUtil.stampResponse("<svg/>", "image/svg+xml", {
+    binary: false,
+  });
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "content-type",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(
+    response.headers.get("content-type"),
+    "image/svg+xml; charset=utf-8",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
+});
+
+Deno.test("WebResponseUtil - stampResponse(binary) emits the full header set", () => {
+  const base64Image =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+  const response = WebResponseUtil.stampResponse(base64Image, "image/png", {
+    binary: true,
+    headers: { "CF-Rocket-Loader": "false" },
+  });
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cf-rocket-loader",
+    "content-length",
+    "content-type",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(response.headers.get("content-type"), "image/png");
+  assertEquals(response.headers.get("content-length"), "70");
+  assertEquals(
+    response.headers.get("vary"),
+    "Accept-Encoding, X-API-Version, Origin",
+  );
+});
+
+Deno.test("WebResponseUtil - stampNotFound carries no-cache security headers", () => {
+  const response = WebResponseUtil.stampNotFound();
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cdn-cache-control",
+    "cloudflare-cdn-cache-control",
+    "content-security-policy",
+    "content-type",
+    "edge-control",
+    "surrogate-control",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(
+    response.headers.get("cache-control"),
+    "no-store, must-revalidate",
+  );
+});
+
+Deno.test("WebResponseUtil - binaryResponse emits recursive security + cache headers", () => {
+  const response = WebResponseUtil.binaryResponse(
+    new Uint8Array([1, 2, 3]),
+    "image/png",
+    { immutableBinary: true, headers: { "X-Cache": "redis-hit" } },
+  );
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cdn-cache-control",
+    "cloudflare-cdn-cache-control",
+    "content-security-policy",
+    "content-type",
+    "cross-origin-embedder-policy",
+    "cross-origin-opener-policy",
+    "cross-origin-resource-policy",
+    "edge-control",
+    "surrogate-control",
+    "vary",
+    "x-api-version",
+    "x-cache",
+  ]);
+  assertEquals(response.headers.get("content-type"), "image/png");
+  assertEquals(
+    response.headers.get("cross-origin-resource-policy"),
+    "cross-origin",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
 });


### PR DESCRIPTION
## Problem

`getHtmlHeaders()`, `getRecursiveHeaders()` and `getBinaryContentHeaders()` in `lib/utils/security/securityHeaders.ts` returned `normalizeHeaders(...)`, i.e. a `Headers` instance. Every consumer merged them with object spread. A `Headers` instance has no own enumerable properties, so `{ ...getHtmlHeaders() }` is `{}` and every security/cache header they were meant to contribute was silently dropped.

Verified on production 2026-09-07:

| Route | Live headers (before) |
|---|---|
| `/content/<tx>.html`, `/s/<tx>` (HTML stamp) | `content-type`, `cache-control`, `cdn-cache-control`, `vary`, `x-api-version`, `x-content-type-options`, `x-frame-options` — only what `sharedContentHandler` sets explicitly; no CSP |
| `/s/<cpid>` (binary stamp via cpid) | **no `content-type` at all**, no cache headers (only `content-length`, `vary`) |
| `/s/<tx>` (SVG stamp) | `content-type`, `vary` only — no cache headers, so CF never edge-caches SVG stamps |

### Broken spreads (all fixed)

`lib/utils/api/responses/webResponseUtil.ts` (line numbers as of `origin/dev` e92da106c):

- `:96` `stampResponse` binary branch — `...headers` (a `Headers` instance built at `:78`) → dropped base + caller headers
- `:97` `stampResponse` binary branch — `...getBinaryContentHeaders(...)` → dropped (this is why binary stamps had no `Content-Type`)
- `:120` `stampResponse` text branch — `...headers` → dropped everything incl. caller `options.headers` (the `CF-*`/upstream headers stampController passes never reached the wire)
- `:141` `stampNotFound` — `...getHtmlHeaders(...)` → dropped
- `:282` `htmlResponse` — `...getHtmlHeaders(...)` → dropped
- `:350` `binaryResponse` — `...getBinaryContentHeaders(...)` → dropped (preview PNGs lost CSP/CORP/cache family)
- `:366` / `:373` `getContentTypeHeaders` html / javascript branches — `...getHtmlHeaders` / `...getRecursiveHeaders` → dropped

`routes/handlers/sharedContentHandler.ts:79-83` used `Object.fromEntries(getRecursiveHeaders())` — that one *worked* (Headers is iterable), but it is only reached on the dead redirect branch (`getStampFile` never returns 3xx since the proxy refactor).

Spreads of `getSecurityHeaders()` (`success`, `notFound`, `internalError`, `jsonResponse`, `custom`, `badRequest`, `xmlResponse`, `ApiResponseUtil.createHeaders`) were already correct — it returns a plain record.

## Fix (at the source)

- `securityHeaders.ts`: the three producers now return `Record<string, string>`; `normalizeHeaders` is applied once, by the response helper, at `new Response()` time (it already was, at every call site). Also fixed a latent aliasing bug in `getSecurityHeaders`: the *first* call for a cache key returned the cached object itself instead of a copy, so a caller mutation would poison the cache.
- `stampResponse` merges through a `Headers` object (base → caller overrides → forced `X-API-Version`/`Vary`/`Content-Type`/`Content-Length`), same pattern as `modifiedResponse` (#1243). `getContentTypeHeaders` is gone; all stamp content goes through the new `getStampContentHeaders(mimeType)`.
- `sharedContentHandler.ts`: the redirect-branch spread now uses `getStampContentHeaders("text/html")`; every previously-explicit header (`Cache-Control: public, max-age=3600, no-transform`, `CDN-Cache-Control: public, max-age=86400`, `Vary: Accept-Encoding`, `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `X-Content-Transformed`) is preserved byte-for-byte on both HTML paths.
- `scripts/check-manual-responses.ts`: removed the vestigial `routes/api/_middleware.ts` exception (no manual `Response()` remains there after #1243). `deno task check:responses` stays green.

## CSP decision for user-generated stamp content

**HTML stamps get `Content-Security-Policy: frame-ancestors 'self'` and nothing else. Non-HTML stamp content (SVG/JS/binary) gets no CSP.**

Evidence — 47 real `text/html` stamps pulled from `/api/v2/stamps?filetypeFilter=html` (pages 1–4) and fetched via `/content/<tx>.html`:

| Pattern | Count / examples |
|---|---|
| inline `<script>` | 31 / 47 |
| inline `<style>` | 37 / 47 |
| inline `on*=` handlers | 10 (e.g. `ea3b6442…` 26 handlers, `3dfc9647…` 14) |
| external `<script src>` | `db0f65ab…` loads three.js from `cdnjs.cloudflare.com` **and** OrbitControls from `cdn.jsdelivr.net` |
| external `<iframe>` | `56d26a2e…` iframes `*.arweave.net` |
| external images | `ordinals.com` (×5), `wonky-ord-v2.dogeord.io`, `hashvatar.vercel.app`, `raw.githubusercontent.com` |
| `blob:` script/worker via `URL.createObjectURL` | `6dc47753…`, `20f48ee7…` |
| `localStorage` | `20f48ee7…` (a WebRTC chat stamp) |
| recursive `/s/<cpid>` refs | `068d0f9c…`, `55b0ee31…`, `8e882bb0…` |
| `<base>`, `<form>`, `<object>/<embed>`, `window.top` | 0 |

Why the alternatives were rejected:

- **Site "web" CSP** (`getSecurityHeaders({context:"web"})`, which `getHtmlHeaders` would have applied had the spread worked): `script-src` is a trusted-domain list (blocks `cdn.jsdelivr.net`, blocks `blob:` scripts), `frame-src 'self'` (blocks the arweave iframe), `connect-src` trusted-only, `default-src` trusted-only (blocks external `<audio>/<video>`). It would break at least 4 of the 47 sampled stamps. Note that production normal pages send **no** CSP at all today (Fresh-rendered pages don't go through `WebResponseUtil`), so the "web" policy is not actually the live site policy either.
- **The pre-existing "recursive" allow-all policy**: adds no protection (every directive is `*`), and its `frame-src *` does not match `data:`/`blob:` schemes, so it could break `<iframe src="data:…">` stamps while protecting nothing. Also its `frame-ancestors *` contradicts the live `X-Frame-Options: SAMEORIGIN`.
- **`sandbox`** (with or without `allow-scripts`): without `allow-same-origin` the document gets an opaque origin, which breaks `localStorage` (see `20f48ee7…`) and same-origin `fetch('/s/…')` (needs CORS). With `allow-same-origin` it protects nothing. Isolating stamp content on a dedicated origin is the real fix and is a separate decision.
- **`base-uri` / `form-action`**: no stamp uses them, but they add zero protection for a document the author fully controls (the author can already exfiltrate via `fetch` to any host).

`frame-ancestors 'self'` is the only directive that is both enforceable and already the live behaviour: it mirrors the `X-Frame-Options: SAMEORIGIN` that `/content/` and `/s/` HTML responses already send (CSP3 gives `frame-ancestors` precedence when both are present, and they agree). The preview worker navigates to `/content/<tx>` top-level, so it is unaffected. `frame-ancestors` is deliberately *not* extended to SVG documents because that would newly block third-party `<iframe>`/`<object>` embeds of SVG stamps (SVG sends no XFO today).

## Behaviour changes (beyond restoring dropped headers)

- HTML stamp responses gain `Content-Security-Policy: frame-ancestors 'self'`. Cache/CDN/XFO/nosniff values unchanged.
- Binary stamps via `/s/<cpid>` now send `Content-Type` and `Cache-Control: public, max-age=31536000, immutable` (was nothing; browsers were sniffing).
- SVG/JS stamps via `/s/` now send the 1-year immutable `Cache-Control` (was nothing), so CF can edge-cache them; matches the explicit intent of the old image branch and the `/content/<tx>.<ext>` binary proxy path, which already forwarded the upstream 1-year headers.
- `stampController` caller headers (`CF-No-Transform`, `CF-Rocket-Loader`, etc., and for the `/content/<tx>.<ext>` text proxy path the upstream `/stamps/` response headers such as `access-control-allow-origin: *`) now actually reach the wire, consistent with the binary proxy branch which already forwarded them. Deno's `fetch` strips `content-length`/`content-encoding` from the upstream response, so no stale framing headers are forwarded (verified with a local `Deno.serve` experiment).
- `htmlResponse` (used by `routes/test/horizon*.ts` and `stampNotFound`) now emits the web CSP + cache family it always claimed to. The test pages reference no external hosts.

## Tests

- `tests/unit/webResponseUtil.test.ts`: the old binary test asserted `Content-Type === null` ("lost during normalization") — it was codifying the bug; it now asserts `image/png`. Added full-header-set assertions (sorted `headers.keys()` equality) for `htmlResponse`, `stampResponse` (html / svg / binary / caller-override), `stampNotFound`, `binaryResponse`.
- `tests/unit/securityHeaders.test.ts` (new): every producer must be a spreadable plain record (regression guard for exactly this bug), `getStampContentHeaders` exact shape, cache copy-on-first-call.

## Gates

```
deno task check:responses   → ✅ No manual Response() usage found - all routes use utility methods!
deno fmt --check && deno lint → Checked 617 files / Checked 724 files (exit 0)
deno check <changed .ts>    → exit 0
deno task test:unit          → ok | 1188 passed (2902 steps) | 0 failed | 7 ignored (41s)
```

## Follow-ups (not in this PR)

- Decide whether stamp content should move to a dedicated origin (or a `sandbox` policy) so author-controlled scripts stop running with the `stampchain.io` origin. That is the only change that meaningfully raises the security floor here.
- Decide whether `frame-ancestors 'self'` should also apply to SVG stamp documents.
- The redirect branch in `sharedContentHandler.ts` (`response.status === 301/302`) looks unreachable since the proxy refactor; left as-is.

Task: 1230@stampchain-io

🤖 Generated with [Claude Code](https://claude.com/claude-code)
