### PR TITLE
Promote dev → main: stamp-content security/cache headers (#1249), BTC balance negative caching (#1248)

### DIFF
--- a/lib/utils/api/responses/webResponseUtil.ts
+++ b/lib/utils/api/responses/webResponseUtil.ts
@@ -1,8 +1,8 @@
 import {
   getBinaryContentHeaders,
   getHtmlHeaders,
-  getRecursiveHeaders,
   getSecurityHeaders,
+  getStampContentHeaders,
 } from "$lib/utils/security/securityHeaders.ts";
 import { normalizeHeaders } from "$lib/utils/api/headers/headerUtils.ts";
 import {
@@ -74,12 +74,14 @@ export class WebResponseUtil {
     mimeType: string,
     options: StampResponseOptions = {},
   ): Response {
-    const baseHeaders = this.getContentTypeHeaders(mimeType, options);
-    const headers = new Headers({
-      ...baseHeaders,
-      ...options.headers,
-      "X-API-Version": API_RESPONSE_VERSION,
-    });
+    // Merge through a Headers object (never spread a Headers instance — it
+    // has no own enumerable properties, so `{ ...headers }` is `{}`).
+    // Caller-supplied headers override the stamp-content defaults.
+    const headers = new Headers(getStampContentHeaders(mimeType, options));
+    for (const [key, value] of Object.entries(options.headers || {})) {
+      headers.set(key, value);
+    }
+    headers.set("X-API-Version", API_RESPONSE_VERSION);
 
     // Binary content handling
     if (options.binary && content) {
@@ -90,16 +92,10 @@ export class WebResponseUtil {
           bytes[i] = binaryString.charCodeAt(i);
         }
 
+        headers.set("Vary", "Accept-Encoding, X-API-Version, Origin");
+        headers.set("Content-Length", bytes.length.toString());
         return new Response(bytes, {
-          headers: normalizeHeaders(
-            new Headers({
-              ...headers,
-              ...getBinaryContentHeaders(mimeType, options),
-              "X-API-Version": API_RESPONSE_VERSION,
-              "Vary": "Accept-Encoding, X-API-Version, Origin",
-              "Content-Length": bytes.length.toString(),
-            }),
-          ),
+          headers: normalizeHeaders(headers),
         });
       } catch (error) {
         console.error("Failed to convert base64 to binary:", error);
@@ -114,15 +110,10 @@ export class WebResponseUtil {
       mimeType.includes("xml");
 
     if (isTextBased) {
+      headers.set("Vary", "Accept-Encoding, X-API-Version, Origin");
+      headers.set("Content-Type", `${mimeType}; charset=utf-8`);
       return new Response(content, {
-        headers: normalizeHeaders(
-          new Headers({
-            ...headers,
-            "X-API-Version": API_RESPONSE_VERSION,
-            "Vary": "Accept-Encoding, X-API-Version, Origin",
-            "Content-Type": `${mimeType}; charset=utf-8`,
-          }),
-        ),
+        headers: normalizeHeaders(headers),
       });
     }
 
@@ -355,48 +346,5 @@ export class WebResponseUtil {
         options.immutableBinary ? { immutableBinary: true } : {},
       ),
     });
-  }
-
-  private static getContentTypeHeaders(
-    mimeType: string,
-    options: StampResponseOptions,
-  ): HeadersInit {
-    if (mimeType.includes("html")) {
-      return {
-        ...getHtmlHeaders(options),
-        "Content-Type": `${mimeType}; charset=utf-8`,
-      };
-    }
-
-    if (mimeType.includes("javascript")) {
-      return {
-        ...getRecursiveHeaders(options),
-        "Content-Type": `${mimeType}; charset=utf-8`,
-      };
-    }
-
-    if (mimeType.includes("image/")) {
-      return {
-        ...getSecurityHeaders(options),
-        "Content-Type": mimeType,
-        "Cache-Control": "public, max-age=31536000, immutable",
-      };
-    }
-
-    if (
-      mimeType.includes("text/") ||
-      mimeType.includes("application/json") ||
-      mimeType.includes("xml")
-    ) {
-      return {
-        ...getSecurityHeaders(options),
-        "Content-Type": `${mimeType}; charset=utf-8`,
-      };
-    }
-
-    return {
-      ...getSecurityHeaders(options),
-      "Content-Type": mimeType,
-    };
   }
 }

--- a/lib/utils/data/processing/balanceUtils.ts
+++ b/lib/utils/data/processing/balanceUtils.ts
@@ -68,48 +68,163 @@ async function getBTCBalanceFromBlockCypher(
   }
 }
 
-// Cached wrapper for getBTCBalanceFromMempool with Redis caching
-async function getCachedBTCBalanceFromMempool(
+/* ===== per-provider caching (positive + short negative) ===== */
+
+type BTCBalanceProvider = "mempool" | "blockcypher";
+
+/** TTL for a successful provider lookup — balances can change frequently. */
+const BTC_BALANCE_CACHE_TTL_S = 60;
+
+/**
+ * TTL for a *failed* provider lookup (`null`: 429 / 5xx / network error /
+ * timeout). `dbManager.handleCache` treats `null` as a cache miss, so without
+ * this a provider that is currently down was re-queried on EVERY cold request,
+ * each one paying up to its full share of the budget (#1198 follow-up) and
+ * hammering the rate-limited providers harder. While the marker is live the
+ * provider is skipped and the chain falls through to the next one (or
+ * degrades) immediately. Kept short so a recovered provider is picked up
+ * again within seconds; a legitimate zero balance is a real `BTCBalance`
+ * object and is never negative-cached.
+ */
+export const BTC_BALANCE_NEGATIVE_CACHE_TTL_S = 20;
+
+/** Sentinel stored under the negative key — never a `BTCBalance` shape. */
+interface BTCBalanceUnavailableMarker {
+  unavailable: true;
+  /** Epoch ms of the failure that created the marker (diagnostics only). */
+  at: number;
+}
+
+function isUnavailableMarker(
+  value: unknown,
+): value is BTCBalanceUnavailableMarker {
+  return typeof value === "object" && value !== null &&
+    (value as BTCBalanceUnavailableMarker).unavailable === true;
+}
+
+/** Positive entries: `btc_balance:{provider}:{address}` (unchanged). */
+function positiveCacheKey(provider: BTCBalanceProvider, address: string) {
+  return `btc_balance:${provider}:${address}`;
+}
+
+/**
+ * Negative entries live in their own namespace so a marker can never be read
+ * back as a balance, and vice versa.
+ */
+export function negativeCacheKey(
+  provider: BTCBalanceProvider,
   address: string,
-  timeoutMs: number,
+) {
+  return `btc_balance:unavailable:${provider}:${address}`;
+}
+
+/**
+ * The slice of `dbManager` the provider cache needs. Injectable so the cache
+ * semantics can be tested against a real (in-memory) `DatabaseManager`
+ * instance; production always uses the shared `dbManager` singleton.
+ */
+export interface BTCBalanceProviderCache {
+  handleCache<T>(
+    key: string,
+    fetchData: () => Promise<T>,
+    cacheDuration: number | "never",
+  ): Promise<T>;
+  getCacheValue<T>(key: string): Promise<T | null>;
+  setCacheValue(
+    key: string,
+    value: unknown,
+    ttlSeconds: number | "never",
+  ): Promise<void>;
+}
+
+/**
+ * Cached wrapper shared by both providers. The positive cache is consulted
+ * first (`handleCache`, 60s); only on a positive miss is the negative marker
+ * checked, so the warm path costs nothing extra. If the provider fails, a
+ * short-lived marker is written so the next requests skip it. Every cache
+ * operation is best-effort: if the cache layer is missing or unavailable the
+ * provider is simply called directly (no caching, negative or positive —
+ * exactly the pre-existing fallback behaviour).
+ */
+export async function getCachedProviderBalance(
+  provider: BTCBalanceProvider,
+  address: string,
+  fetchFresh: () => Promise<BTCBalance | null>,
+  cache: BTCBalanceProviderCache | undefined = dbManager,
 ): Promise<BTCBalance | null> {
-  const cacheKey = `btc_balance:mempool:${address}`;
-  const cacheDuration = 60; // 60 seconds TTL - balances can change frequently
-  const fetchFresh = () =>
-    getBTCBalanceFromMempool(address, 0, Date.now() + timeoutMs);
+  const negativeKey = negativeCacheKey(provider, address);
+
+  const recentlyFailed = async (): Promise<boolean> => {
+    try {
+      return isUnavailableMarker(await cache?.getCacheValue(negativeKey));
+    } catch (error) {
+      console.error(`Negative-cache read failed for ${provider}:`, error);
+      return false;
+    }
+  };
+
+  const recordFailure = async (): Promise<void> => {
+    const marker: BTCBalanceUnavailableMarker = {
+      unavailable: true,
+      at: Date.now(),
+    };
+    try {
+      await cache?.setCacheValue(
+        negativeKey,
+        marker,
+        BTC_BALANCE_NEGATIVE_CACHE_TTL_S,
+      );
+    } catch (error) {
+      console.error(`Negative-cache write failed for ${provider}:`, error);
+    }
+  };
+
+  const fetchUnlessRecentlyFailed = async (): Promise<BTCBalance | null> => {
+    if (await recentlyFailed()) {
+      console.warn(
+        `Skipping ${provider} balance lookup for ${address}: provider failed within the last ${BTC_BALANCE_NEGATIVE_CACHE_TTL_S}s`,
+      );
+      return null;
+    }
+    const balance = await fetchFresh();
+    if (balance === null) await recordFailure();
+    return balance;
+  };
 
   try {
-    return await dbManager.handleCache(
-      cacheKey,
-      fetchFresh,
-      cacheDuration,
+    if (!cache) return await fetchUnlessRecentlyFailed();
+    return await cache.handleCache(
+      positiveCacheKey(provider, address),
+      fetchUnlessRecentlyFailed,
+      BTC_BALANCE_CACHE_TTL_S,
     ) as BTCBalance | null;
   } catch (error) {
-    console.error("Cached balance fetch error:", error);
+    console.error(`Cached ${provider} balance fetch error:`, error);
     // Fallback to direct call if caching fails
-    return fetchFresh();
+    return fetchUnlessRecentlyFailed();
   }
 }
 
-// Cached wrapper for getBTCBalanceFromBlockCypher with Redis caching
-async function getCachedBTCBalanceFromBlockCypher(
+function getCachedBTCBalanceFromMempool(
   address: string,
   timeoutMs: number,
 ): Promise<BTCBalance | null> {
-  const cacheKey = `btc_balance:blockcypher:${address}`;
-  const cacheDuration = 60; // 60 seconds TTL
+  return getCachedProviderBalance(
+    "mempool",
+    address,
+    () => getBTCBalanceFromMempool(address, 0, Date.now() + timeoutMs),
+  );
+}
 
-  try {
-    return await dbManager.handleCache(
-      cacheKey,
-      () => getBTCBalanceFromBlockCypher(address, timeoutMs),
-      cacheDuration,
-    ) as BTCBalance | null;
-  } catch (error) {
-    console.error("Cached BlockCypher balance fetch error:", error);
-    // Fallback to direct call if caching fails
-    return getBTCBalanceFromBlockCypher(address, timeoutMs);
-  }
+function getCachedBTCBalanceFromBlockCypher(
+  address: string,
+  timeoutMs: number,
+): Promise<BTCBalance | null> {
+  return getCachedProviderBalance(
+    "blockcypher",
+    address,
+    () => getBTCBalanceFromBlockCypher(address, timeoutMs),
+  );
 }
 
 export async function getBTCBalanceInfo(

--- a/lib/utils/security/securityHeaders.ts
+++ b/lib/utils/security/securityHeaders.ts
@@ -1,5 +1,3 @@
-import { normalizeHeaders } from "$lib/utils/api/headers/headerUtils.ts";
-
 // Cache for security headers to improve performance
 const securityHeaderCache = new Map<string, Record<string, string>>();
 
@@ -125,23 +123,87 @@ export const getSecurityHeaders = (
   // Cache the headers for future use
   securityHeaderCache.set(cacheKey, headers);
 
-  return headers;
+  return { ...headers }; // first call must not hand out the cached object
 };
 
-export const getHtmlHeaders = (options?: { forceNoCache?: boolean }) =>
-  normalizeHeaders({
-    ...getSecurityHeaders({ ...options, context: "web" }),
-    "Content-Type": "text/html; charset=utf-8",
-  });
+/**
+ * Plain-record header producers.
+ *
+ * These MUST return plain objects, never `Headers` instances: every consumer
+ * merges them with object spread (`{ ...getHtmlHeaders(), ... }`), and a
+ * `Headers` instance has no own enumerable properties, so spreading one
+ * silently yields `{}` and drops every header it was meant to contribute.
+ * `normalizeHeaders` is applied once, by the response helper, at
+ * `new Response(...)` time.
+ */
+export const getHtmlHeaders = (
+  options?: { forceNoCache?: boolean },
+): Record<string, string> => ({
+  ...getSecurityHeaders({ ...options, context: "web" }),
+  "Content-Type": "text/html; charset=utf-8",
+});
 
-export const getRecursiveHeaders = (options?: { forceNoCache?: boolean }) =>
-  normalizeHeaders(getSecurityHeaders({ ...options, context: "recursive" }));
+export const getRecursiveHeaders = (
+  options?: { forceNoCache?: boolean },
+): Record<string, string> =>
+  getSecurityHeaders({ ...options, context: "recursive" });
 
 export const getBinaryContentHeaders = (
   mimeType: string,
   options?: { forceNoCache?: boolean },
-) =>
-  normalizeHeaders({
-    ...getSecurityHeaders({ ...options, context: "recursive" }),
+): Record<string, string> => ({
+  ...getSecurityHeaders({ ...options, context: "recursive" }),
+  "Content-Type": mimeType,
+});
+
+/**
+ * CSP for user-generated HTML stamp content served from `/content/` and `/s/`.
+ *
+ * Stamp HTML is fully author-controlled and is served from the site origin,
+ * so no source-list directive can constrain it without breaking real stamps:
+ * the on-chain corpus uses inline `<script>`/`<style>`/`on*=` handlers,
+ * `blob:` workers, `localStorage`, and loads scripts, images and iframes
+ * from arbitrary hosts (ordinals.com, arweave.net, cdn.jsdelivr.net,
+ * *.vercel.app, ...). The site "web" policy from `getSecurityHeaders` would
+ * block several of those, and CSP `sandbox` would change origin semantics
+ * (localStorage, same-origin fetch) for every stamp.
+ *
+ * The one directive that is both enforceable and already the live behaviour
+ * is embedding: `frame-ancestors 'self'` mirrors the `X-Frame-Options:
+ * SAMEORIGIN` that `/content/` and `/s/` HTML responses already send, and
+ * CSP3 gives `frame-ancestors` precedence when both are present, so the two
+ * agree. Resource loading is deliberately left unrestricted. Isolating stamp
+ * content on its own origin (or a `sandbox` policy) is a separate decision.
+ */
+export const STAMP_CONTENT_CSP = "frame-ancestors 'self'";
+
+/**
+ * Headers for stamp content (any MIME type) served by `WebResponseUtil.stampResponse`.
+ *
+ * Stamp content is immutable once inscribed, so the browser cache policy is
+ * the long-lived immutable one unless `forceNoCache` is set. Callers that
+ * need a different edge policy (e.g. the HTML paths in
+ * `routes/handlers/sharedContentHandler.ts`) override `Cache-Control` /
+ * `CDN-Cache-Control` explicitly. HTML additionally gets the embedding
+ * policy above plus `nosniff`; non-HTML types get no CSP so that SVG/JS
+ * stamps keep their current unrestricted behaviour (extending
+ * `frame-ancestors` to SVG documents would newly block third-party
+ * `<iframe>`/`<object>` embeds and is out of scope here).
+ */
+export const getStampContentHeaders = (
+  mimeType: string,
+  options: { forceNoCache?: boolean } = {},
+): Record<string, string> => {
+  const headers: Record<string, string> = {
     "Content-Type": mimeType,
-  });
+    "Cache-Control": options.forceNoCache
+      ? "no-store, must-revalidate"
+      : "public, max-age=31536000, immutable",
+  };
+  if (mimeType.toLowerCase().includes("html")) {
+    headers["Content-Security-Policy"] = STAMP_CONTENT_CSP;
+    headers["X-Frame-Options"] = "SAMEORIGIN";
+    headers["X-Content-Type-Options"] = "nosniff";
+  }
+  return { ...headers }; // first call must not hand out the cached object
+};

--- a/routes/handlers/sharedContentHandler.ts
+++ b/routes/handlers/sharedContentHandler.ts
@@ -3,7 +3,7 @@ import { getIdentifierType } from "$lib/utils/data/identifiers/identifierUtils.t
 import { isCpid, isTxHash } from "$lib/utils/typeGuards.ts";
 import { logger } from "$lib/utils/logger.ts";
 import { cleanHtmlForRendering } from "$lib/utils/ui/rendering/htmlCleanup.ts";
-import { getRecursiveHeaders } from "$lib/utils/security/securityHeaders.ts";
+import { getStampContentHeaders } from "$lib/utils/security/securityHeaders.ts";
 import { WebResponseUtil } from "$lib/utils/api/responses/webResponseUtil.ts";
 import { StampController } from "$server/controller/stampController.ts";
 import { RouteType } from "$server/services/infrastructure/cacheService.ts";
@@ -75,11 +75,11 @@ export async function handleContentRequest(
             const rawHtml = await contentResponse.text();
             const htmlContent = cleanHtmlForRendering(rawHtml);
 
-            // Use the standardized HTML response method with headers to prevent CDN modifications
-            const recursiveHeaders = getRecursiveHeaders();
+            // Stamp-content headers (CSP frame-ancestors, nosniff) plus explicit
+            // edge-cache / CDN-transform overrides.
             return WebResponseUtil.htmlResponse(htmlContent, {
               headers: {
-                ...Object.fromEntries(recursiveHeaders),
+                ...getStampContentHeaders("text/html"),
                 // Allow Cloudflare CDN to cache stamp content at the edge.
                 // Stamp data is immutable — once inscribed it never changes.
                 // Edge caching is critical for recursive stamps where the CF

--- a/scripts/check-manual-responses.ts
+++ b/scripts/check-manual-responses.ts
@@ -20,7 +20,6 @@ const EXCEPTIONS = [
   // These files are allowed to have manual Response() for specific reasons
   "routes/test/",
   "routes/_middleware.ts", // Complex middleware with custom headers
-  "routes/api/_middleware.ts", // API middleware with transformation
   "routes/api/v2/stamp/[stamp]/preview.ts", // Binary image processing with specialized headers
 ];
 

--- a/server/database/databaseManager.ts
+++ b/server/database/databaseManager.ts
@@ -1182,6 +1182,39 @@ class DatabaseManager {
     }
   }
 
+  /**
+   * Read a raw cache entry without fetching on a miss. Uses the same
+   * Redis -> in-memory fallback as `handleCache`, and returns `null` on a
+   * miss, an expired entry, or a cache-layer error. Intended for callers
+   * that keep their own marker entries (e.g. short negative-cache markers)
+   * next to the `handleCache`-managed values.
+   */
+  public async getCacheValue<T = unknown>(key: string): Promise<T | null> {
+    try {
+      return (await this.getCachedData(key)) as T | null;
+    } catch (error) {
+      console.log(`[CACHE GET ERROR] ${key.substring(0, 12)}...: ${error instanceof Error ? error.message : error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Write a raw cache entry with a TTL (seconds). Same Redis -> in-memory
+   * fallback and expiry semantics as the values `handleCache` stores; a
+   * non-positive TTL is a no-op in Redis. Never throws.
+   */
+  public async setCacheValue(
+    key: string,
+    value: unknown,
+    ttlSeconds: number | "never",
+  ): Promise<void> {
+    try {
+      await this.setCachedData(key, value, ttlSeconds);
+    } catch (error) {
+      console.log(`[CACHE SET ERROR] ${key.substring(0, 12)}...: ${error instanceof Error ? error.message : error}`);
+    }
+  }
+
   private async getCachedData(key: string): Promise<unknown | null> {
     const REDIS_DEBUG = serverConfig.REDIS_DEBUG;
 

--- a/tests/unit/securityHeaders.test.ts
+++ b/tests/unit/securityHeaders.test.ts
@@ -1,0 +1,105 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  getBinaryContentHeaders,
+  getHtmlHeaders,
+  getRecursiveHeaders,
+  getSecurityHeaders,
+  getStampContentHeaders,
+  STAMP_CONTENT_CSP,
+} from "$lib/utils/security/securityHeaders.ts";
+
+// Every producer is consumed via object spread. A `Headers` instance has no own
+// enumerable properties, so spreading one yields {} and drops everything — the
+// exact regression that hid the security headers on stamp content (task 1230).
+function assertPlainRecord(name: string, value: unknown) {
+  assertEquals(value instanceof Headers, false, `${name} returned Headers`);
+  assertEquals(
+    Object.keys(value as object).length > 0,
+    true,
+    `${name} has no own enumerable keys`,
+  );
+  assertEquals(
+    Object.keys({ ...(value as object) }).length,
+    Object.keys(value as object).length,
+    `${name} loses keys when spread`,
+  );
+}
+
+Deno.test("securityHeaders - producers return spreadable plain records", () => {
+  assertPlainRecord("getSecurityHeaders", getSecurityHeaders());
+  assertPlainRecord("getHtmlHeaders", getHtmlHeaders());
+  assertPlainRecord("getRecursiveHeaders", getRecursiveHeaders());
+  assertPlainRecord(
+    "getBinaryContentHeaders",
+    getBinaryContentHeaders("image/png"),
+  );
+  assertPlainRecord(
+    "getStampContentHeaders",
+    getStampContentHeaders("text/html"),
+  );
+});
+
+Deno.test("securityHeaders - getHtmlHeaders = web policy + html content type", () => {
+  const headers = getHtmlHeaders();
+  assertEquals(headers["Content-Type"], "text/html; charset=utf-8");
+  assertEquals(
+    headers["Content-Security-Policy"],
+    getSecurityHeaders({ context: "web" })["Content-Security-Policy"],
+  );
+  assertEquals(
+    getHtmlHeaders({ forceNoCache: true })["Cache-Control"],
+    "no-store, must-revalidate",
+  );
+});
+
+Deno.test("securityHeaders - getRecursiveHeaders / getBinaryContentHeaders use the recursive policy", () => {
+  const recursive = getRecursiveHeaders();
+  assertEquals(recursive["Cross-Origin-Resource-Policy"], "cross-origin");
+  assertEquals(
+    recursive["Content-Security-Policy"].includes("frame-ancestors *"),
+    true,
+  );
+
+  const binary = getBinaryContentHeaders("image/gif");
+  assertEquals(binary["Content-Type"], "image/gif");
+  assertEquals(
+    binary["Content-Security-Policy"],
+    recursive["Content-Security-Policy"],
+  );
+});
+
+Deno.test("securityHeaders - getStampContentHeaders(html) = embedding policy only", () => {
+  const headers = getStampContentHeaders("text/html");
+  assertEquals(headers, {
+    "Content-Type": "text/html",
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "Content-Security-Policy": STAMP_CONTENT_CSP,
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-Content-Type-Options": "nosniff",
+  });
+  assertEquals(STAMP_CONTENT_CSP, "frame-ancestors 'self'");
+});
+
+Deno.test("securityHeaders - getStampContentHeaders(non-html) has no CSP", () => {
+  for (const mime of ["image/svg+xml", "application/javascript", "image/png"]) {
+    const headers = getStampContentHeaders(mime);
+    assertEquals(headers, {
+      "Content-Type": mime,
+      "Cache-Control": "public, max-age=31536000, immutable",
+    });
+  }
+  assertEquals(
+    getStampContentHeaders("image/png", { forceNoCache: true })[
+      "Cache-Control"
+    ],
+    "no-store, must-revalidate",
+  );
+});
+
+Deno.test("securityHeaders - getSecurityHeaders returns a fresh copy per call", () => {
+  const first = getSecurityHeaders({ context: "api" });
+  first["Cache-Control"] = "mutated";
+  const second = getSecurityHeaders({ context: "api" });
+  assertExists(second["Cache-Control"]);
+  assertEquals(second["Cache-Control"] === "mutated", false);
+});

--- a/tests/unit/utils/btcBalanceNegativeCache.test.ts
+++ b/tests/unit/utils/btcBalanceNegativeCache.test.ts
@@ -1,0 +1,296 @@
+import { assert, assertEquals } from "@std/assert";
+import { spy, stub } from "@std/testing/mock";
+import { FakeTime } from "@std/testing/time";
+import {
+  BTC_BALANCE_NEGATIVE_CACHE_TTL_S,
+  type BTCBalanceProviderCache,
+  getBTCBalanceInfo,
+  getCachedProviderBalance,
+  negativeCacheKey,
+} from "$lib/utils/data/processing/balanceUtils.ts";
+import { DatabaseManager } from "$server/database/databaseManager.ts";
+import type { BTCBalance } from "$lib/types/index.d.ts";
+
+// Follow-up to #1246 (task 1217, #1198): `dbManager.handleCache` treats a
+// `null` result as a cache miss, so a provider that is currently failing
+// (429 / 5xx / timeout) was re-queried on EVERY cold request, each one paying
+// up to its share of the budget and hammering the rate-limited providers
+// harder. Failed lookups now leave a short-lived negative marker (own key
+// namespace, sentinel value) so the provider is skipped within the window.
+// A legitimate zero balance is a real `BTCBalance` object and must keep the
+// normal positive TTL.
+//
+// The cache semantics are exercised against a REAL `DatabaseManager` instance
+// that is never initialised, so it runs on its in-memory fallback (Redis
+// unavailable) — the same code path production takes when Redis is down. The
+// module-level `dbManager` singleton is `undefined` under DENO_ENV=test, which
+// doubles as the "cache layer missing" case.
+
+/** In-memory-only cache: same class as production, Redis never connected. */
+function inMemoryCache(): BTCBalanceProviderCache {
+  return new DatabaseManager({
+    DB_HOST: "localhost",
+    DB_USER: "test",
+    DB_PASSWORD: "",
+    DB_PORT: 3306,
+    DB_NAME: "test",
+    DB_MAX_RETRIES: 1,
+    ELASTICACHE_ENDPOINT: "",
+    DENO_ENV: "test",
+  });
+}
+
+const ZERO_BALANCE: BTCBalance = {
+  confirmed: 0,
+  unconfirmed: 0,
+  total: 0,
+  txCount: 2,
+  unconfirmedTxCount: 0,
+};
+
+const SOME_BALANCE: BTCBalance = {
+  confirmed: 15330,
+  unconfirmed: 0,
+  total: 15330,
+  txCount: 981,
+  unconfirmedTxCount: 0,
+};
+
+const ADDR = "bc1qzxszplp8v7w0jc89dlrqyct9staqlhwxzy7lkq";
+
+/* ===== failing provider is skipped within the negative window ===== */
+
+Deno.test("a failing provider is skipped within the negative-cache window and retried after it", async () => {
+  const cache = inMemoryCache();
+  const provider = spy(() => Promise.resolve<BTCBalance | null>(null));
+  let time: FakeTime | undefined;
+  try {
+    assertEquals(
+      await getCachedProviderBalance("mempool", ADDR, provider, cache),
+      null,
+    );
+    assertEquals(provider.calls.length, 1);
+
+    // The failure left a negative marker in its own namespace, and NO
+    // positive entry (a marker can never be read back as a balance).
+    const marker = await cache.getCacheValue<{ unavailable?: boolean }>(
+      negativeCacheKey("mempool", ADDR),
+    );
+    assertEquals(marker?.unavailable, true);
+    assertEquals(
+      await cache.getCacheValue(`btc_balance:mempool:${ADDR}`),
+      null,
+    );
+
+    // Inside the window: the provider is not contacted again; the wrapper
+    // degrades immediately instead of re-paying the provider budget.
+    const started = Date.now();
+    assertEquals(
+      await getCachedProviderBalance("mempool", ADDR, provider, cache),
+      null,
+    );
+    assertEquals(provider.calls.length, 1);
+    assert(Date.now() - started < 100, "negative hit must be near-instant");
+
+    // Past the window: the marker has expired and the provider is probed
+    // again (and re-marked, since it still fails).
+    time = new FakeTime();
+    time.tick((BTC_BALANCE_NEGATIVE_CACHE_TTL_S + 1) * 1000);
+    assertEquals(
+      await getCachedProviderBalance("mempool", ADDR, provider, cache),
+      null,
+    );
+    assertEquals(provider.calls.length, 2);
+    assertEquals(
+      (await cache.getCacheValue<{ unavailable?: boolean }>(
+        negativeCacheKey("mempool", ADDR),
+      ))?.unavailable,
+      true,
+    );
+  } finally {
+    time?.restore();
+  }
+});
+
+Deno.test("a negative marker for one provider does not affect the other provider or another address", async () => {
+  const cache = inMemoryCache();
+  const failing = spy(() => Promise.resolve<BTCBalance | null>(null));
+  const healthy = spy(() => Promise.resolve<BTCBalance | null>(SOME_BALANCE));
+
+  assertEquals(
+    await getCachedProviderBalance("mempool", ADDR, failing, cache),
+    null,
+  );
+  // Same address, other provider: still called (the chain's fall-through).
+  assertEquals(
+    await getCachedProviderBalance("blockcypher", ADDR, healthy, cache),
+    SOME_BALANCE,
+  );
+  // Same provider, other address: still called.
+  assertEquals(
+    await getCachedProviderBalance("mempool", "other-address", healthy, cache),
+    SOME_BALANCE,
+  );
+  assertEquals(failing.calls.length, 1);
+  assertEquals(healthy.calls.length, 2);
+});
+
+/* ===== a real zero balance is a positive result ===== */
+
+Deno.test("a legitimate zero balance is cached as a positive with the normal TTL, never negatively", async () => {
+  const cache = inMemoryCache();
+  const provider = spy(() => Promise.resolve<BTCBalance | null>(ZERO_BALANCE));
+  let time: FakeTime | undefined;
+  try {
+    assertEquals(
+      await getCachedProviderBalance("mempool", ADDR, provider, cache),
+      ZERO_BALANCE,
+    );
+    assertEquals(provider.calls.length, 1);
+
+    // Positive entry holds the zero balance; no negative marker exists.
+    const positive = await cache.getCacheValue<BTCBalance>(
+      `btc_balance:mempool:${ADDR}`,
+    );
+    assertEquals(positive?.confirmed, 0);
+    assertEquals(positive?.txCount, 2);
+    assertEquals(
+      await cache.getCacheValue(negativeCacheKey("mempool", ADDR)),
+      null,
+    );
+
+    // Still a cache hit after the NEGATIVE window has passed: the zero
+    // balance was stored with the positive (60s) TTL, not the short one.
+    time = new FakeTime();
+    time.tick((BTC_BALANCE_NEGATIVE_CACHE_TTL_S + 1) * 1000);
+    assertEquals(
+      await getCachedProviderBalance("mempool", ADDR, provider, cache),
+      ZERO_BALANCE,
+    );
+    assertEquals(provider.calls.length, 1);
+  } finally {
+    time?.restore();
+  }
+});
+
+Deno.test("the provider chain reports a zero balance rather than degrading", async () => {
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () =>
+      Promise.resolve(
+        Response.json({
+          address: ADDR,
+          chain_stats: {
+            funded_txo_count: 2,
+            funded_txo_sum: 5000,
+            spent_txo_count: 2,
+            spent_txo_sum: 5000, // everything spent: 0 sats left
+            tx_count: 4,
+          },
+          mempool_stats: {
+            funded_txo_count: 0,
+            funded_txo_sum: 0,
+            spent_txo_count: 0,
+            spent_txo_sum: 0,
+            tx_count: 0,
+          },
+        }),
+      ),
+  );
+  try {
+    const info = await getBTCBalanceInfo(ADDR, { timeoutMs: 600 });
+    assert(info !== null, "zero balance must be reported, not degraded");
+    assertEquals(info.balance, 0);
+    assertEquals(info.unconfirmedBalance, 0);
+    assertEquals(info.txCount, 4);
+    assertEquals(fetchStub.calls.length, 1); // mempool answered; no fallback
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+/* ===== negative marker is never surfaced as a balance ===== */
+
+Deno.test("a live negative marker is honoured without contacting the provider and is never returned as a balance", async () => {
+  const cache = inMemoryCache();
+  await cache.setCacheValue(
+    negativeCacheKey("mempool", ADDR),
+    { unavailable: true, at: Date.now() },
+    BTC_BALANCE_NEGATIVE_CACHE_TTL_S,
+  );
+  const provider = spy(() => Promise.resolve<BTCBalance | null>(SOME_BALANCE));
+  const result = await getCachedProviderBalance(
+    "mempool",
+    ADDR,
+    provider,
+    cache,
+  );
+  assertEquals(result, null); // the marker object must not leak out
+  assertEquals(provider.calls.length, 0);
+});
+
+/* ===== cache layer unavailable: degrade to no caching ===== */
+
+Deno.test("with no cache layer at all, providers are called every time and failures still return null", async () => {
+  const failing = spy(() => Promise.resolve<BTCBalance | null>(null));
+  const healthy = spy(() => Promise.resolve<BTCBalance | null>(SOME_BALANCE));
+
+  assertEquals(
+    await getCachedProviderBalance("mempool", ADDR, failing, undefined),
+    null,
+  );
+  assertEquals(
+    await getCachedProviderBalance("mempool", ADDR, failing, undefined),
+    null,
+  );
+  assertEquals(failing.calls.length, 2); // no negative caching without a cache
+  assertEquals(
+    await getCachedProviderBalance("mempool", ADDR, healthy, undefined),
+    SOME_BALANCE,
+  );
+  assertEquals(healthy.calls.length, 1);
+});
+
+Deno.test("with a cache layer that throws on every operation, providers are still called and nothing throws", async () => {
+  const broken: BTCBalanceProviderCache = {
+    handleCache: () => Promise.reject(new Error("redis down")),
+    getCacheValue: () => Promise.reject(new Error("redis down")),
+    setCacheValue: () => Promise.reject(new Error("redis down")),
+  };
+  const failing = spy(() => Promise.resolve<BTCBalance | null>(null));
+  const healthy = spy(() => Promise.resolve<BTCBalance | null>(SOME_BALANCE));
+
+  assertEquals(
+    await getCachedProviderBalance("blockcypher", ADDR, failing, broken),
+    null,
+  );
+  assertEquals(
+    await getCachedProviderBalance("blockcypher", ADDR, failing, broken),
+    null,
+  );
+  assertEquals(failing.calls.length, 2);
+  assertEquals(
+    await getCachedProviderBalance("blockcypher", ADDR, healthy, broken),
+    SOME_BALANCE,
+  );
+  assertEquals(healthy.calls.length, 1);
+});
+
+Deno.test("the provider chain still degrades cleanly when every provider fails and no cache is available", async () => {
+  // Under DENO_ENV=test the module-level dbManager singleton is undefined:
+  // the real chain must neither throw nor mistake that for a failure.
+  const fetchStub = stub(
+    globalThis,
+    "fetch",
+    () => Promise.resolve(new Response("rate limited", { status: 429 })),
+  );
+  try {
+    assertEquals(await getBTCBalanceInfo(ADDR, { timeoutMs: 600 }), null);
+    assertEquals(fetchStub.calls.length, 2); // mempool + BlockCypher, no retries
+    assertEquals(await getBTCBalanceInfo(ADDR, { timeoutMs: 600 }), null);
+    assertEquals(fetchStub.calls.length, 4); // no cache => probed again
+  } finally {
+    fetchStub.restore();
+  }
+});

--- a/tests/unit/webResponseUtil.test.ts
+++ b/tests/unit/webResponseUtil.test.ts
@@ -189,8 +189,11 @@ Deno.test("WebResponseUtil - stampResponse with binary image", async () => {
     binary: true,
   });
 
-  // Content-Type header is lost during normalization for binary responses
-  assertEquals(response.headers.get("Content-Type"), null);
+  assertEquals(response.headers.get("Content-Type"), "image/png");
+  assertEquals(
+    response.headers.get("Cache-Control"),
+    "public, max-age=31536000, immutable",
+  );
   assertExists(response.headers.get("Content-Length"));
 
   const body = await response.arrayBuffer();
@@ -315,5 +318,230 @@ Deno.test("WebResponseUtil - xmlResponse sets XML content type and honours cache
 
 Deno.test("WebResponseUtil - xmlResponse defaults to security-header cache policy", () => {
   const response = WebResponseUtil.xmlResponse("<a/>", { forceNoCache: true });
-  assertEquals(response.headers.get("cache-control"), "no-store, must-revalidate");
+  assertEquals(
+    response.headers.get("cache-control"),
+    "no-store, must-revalidate",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Full header-set assertions. The header producers in securityHeaders.ts used
+// to return Headers instances; spreading one into an object literal yields {}
+// and silently dropped every security/cache header (task 1230). These tests
+// pin the complete set so a regression cannot hide behind assertExists.
+// ---------------------------------------------------------------------------
+
+function headerNames(response: Response): string[] {
+  return [...response.headers.keys()].sort();
+}
+
+Deno.test("WebResponseUtil - htmlResponse emits the full web security header set", () => {
+  const response = WebResponseUtil.htmlResponse("<p>x</p>");
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cdn-cache-control",
+    "cloudflare-cdn-cache-control",
+    "content-security-policy",
+    "content-type",
+    "edge-control",
+    "surrogate-control",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
+  const csp = response.headers.get("content-security-policy") ?? "";
+  assertEquals(csp.includes("frame-ancestors 'self'"), true);
+  assertEquals(csp.includes("script-src"), true);
+});
+
+Deno.test("WebResponseUtil - htmlResponse forceNoCache + caller overrides", () => {
+  const response = WebResponseUtil.htmlResponse("<p>x</p>", {
+    forceNoCache: true,
+    headers: { "X-Frame-Options": "SAMEORIGIN", "Vary": "Accept-Encoding" },
+  });
+
+  assertEquals(
+    response.headers.get("cache-control"),
+    "no-store, must-revalidate",
+  );
+  assertEquals(response.headers.get("x-frame-options"), "SAMEORIGIN");
+  assertExists(response.headers.get("content-security-policy"));
+});
+
+Deno.test("WebResponseUtil - stampResponse(text/html) emits the stamp-content header set", () => {
+  const response = WebResponseUtil.stampResponse("<p>x</p>", "text/html", {
+    binary: false,
+  });
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "content-security-policy",
+    "content-type",
+    "vary",
+    "x-api-version",
+    "x-content-type-options",
+    "x-frame-options",
+  ]);
+  assertEquals(
+    response.headers.get("content-security-policy"),
+    "frame-ancestors 'self'",
+  );
+  assertEquals(response.headers.get("x-frame-options"), "SAMEORIGIN");
+  assertEquals(response.headers.get("x-content-type-options"), "nosniff");
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
+  assertEquals(
+    response.headers.get("vary"),
+    "Accept-Encoding, X-API-Version, Origin",
+  );
+});
+
+Deno.test("WebResponseUtil - stampResponse(text/html) never carries the site web CSP", () => {
+  const response = WebResponseUtil.stampResponse("<p>x</p>", "text/html", {
+    binary: false,
+  });
+  const csp = response.headers.get("content-security-policy") ?? "";
+  // Real HTML stamps load scripts/iframes/images from arbitrary hosts and use
+  // blob: workers; a source-list CSP would break them.
+  assertEquals(csp.includes("script-src"), false);
+  assertEquals(csp.includes("default-src"), false);
+  assertEquals(csp.includes("connect-src"), false);
+});
+
+Deno.test("WebResponseUtil - stampResponse caller headers override defaults", () => {
+  const response = WebResponseUtil.stampResponse("<p>x</p>", "text/html", {
+    binary: false,
+    headers: {
+      "Cache-Control": "public, max-age=3600, no-transform",
+      "CDN-Cache-Control": "public, max-age=86400",
+      "CF-No-Transform": "true",
+    },
+  });
+
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=3600, no-transform",
+  );
+  assertEquals(
+    response.headers.get("cdn-cache-control"),
+    "public, max-age=86400",
+  );
+  assertEquals(response.headers.get("cf-no-transform"), "true");
+  // Forced trailing headers still win over caller values.
+  assertEquals(
+    response.headers.get("content-type"),
+    "text/html; charset=utf-8",
+  );
+});
+
+Deno.test("WebResponseUtil - stampResponse(image/svg+xml) has cache headers and no CSP", () => {
+  const response = WebResponseUtil.stampResponse("<svg/>", "image/svg+xml", {
+    binary: false,
+  });
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "content-type",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(
+    response.headers.get("content-type"),
+    "image/svg+xml; charset=utf-8",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
+});
+
+Deno.test("WebResponseUtil - stampResponse(binary) emits the full header set", () => {
+  const base64Image =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+  const response = WebResponseUtil.stampResponse(base64Image, "image/png", {
+    binary: true,
+    headers: { "CF-Rocket-Loader": "false" },
+  });
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cf-rocket-loader",
+    "content-length",
+    "content-type",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(response.headers.get("content-type"), "image/png");
+  assertEquals(response.headers.get("content-length"), "70");
+  assertEquals(
+    response.headers.get("vary"),
+    "Accept-Encoding, X-API-Version, Origin",
+  );
+});
+
+Deno.test("WebResponseUtil - stampNotFound carries no-cache security headers", () => {
+  const response = WebResponseUtil.stampNotFound();
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cdn-cache-control",
+    "cloudflare-cdn-cache-control",
+    "content-security-policy",
+    "content-type",
+    "edge-control",
+    "surrogate-control",
+    "vary",
+    "x-api-version",
+  ]);
+  assertEquals(
+    response.headers.get("cache-control"),
+    "no-store, must-revalidate",
+  );
+});
+
+Deno.test("WebResponseUtil - binaryResponse emits recursive security + cache headers", () => {
+  const response = WebResponseUtil.binaryResponse(
+    new Uint8Array([1, 2, 3]),
+    "image/png",
+    { immutableBinary: true, headers: { "X-Cache": "redis-hit" } },
+  );
+
+  assertEquals(headerNames(response), [
+    "cache-control",
+    "cdn-cache-control",
+    "cloudflare-cdn-cache-control",
+    "content-security-policy",
+    "content-type",
+    "cross-origin-embedder-policy",
+    "cross-origin-opener-policy",
+    "cross-origin-resource-policy",
+    "edge-control",
+    "surrogate-control",
+    "vary",
+    "x-api-version",
+    "x-cache",
+  ]);
+  assertEquals(response.headers.get("content-type"), "image/png");
+  assertEquals(
+    response.headers.get("cross-origin-resource-policy"),
+    "cross-origin",
+  );
+  assertEquals(
+    response.headers.get("cache-control"),
+    "public, max-age=31536000, immutable",
+  );
 });


### PR DESCRIPTION
Promotes two squash commits from `dev` to `main`, triggering the production deploy.

| commit | what |
|---|---|
| `bae42548f` | **#1249** (task 1230) Header producers returned `Headers` instances that were object-spread, silently dropping every security/cache header at 8 sites. Now plain records merged through a `Headers` object. Effects on the wire: `/s/<cpid>` binary stamps gain the `Content-Type` and 1-year immutable `Cache-Control` they were missing entirely; HTML stamp content (`/s/`, `/content/*.html`) gains `Content-Security-Policy: frame-ancestors 'self'` (mirrors the existing `X-Frame-Options: SAMEORIGIN`; chosen after checking 47 real HTML stamps, which use inline scripts, blob: workers, localStorage and third-party CDNs that the site CSP would block); SVG/JS via `/s/` gain the same 1-year cache the `/content/*.svg` proxy path already sends; caller headers (`CF-No-Transform`) and upstream CORS headers now reach the wire. Local A/B against current `dev` on the seeded stack: all differences additive, nothing removed. |
| `036142cc6` | **#1248** (task 1217 follow-up) Failed BTC provider lookups get a 20 s negative-cache marker in a separate key namespace, so a provider outage costs one probe per address per window instead of the full 3 s budget on every cold request. Zero balances are never negative-cached; markers can never be returned as balances. Two additive read/write accessors on `DatabaseManager`. |

## Validation on the merged `dev` tree (`bae42548f`)
- `deno task check` (fmt, lint, type-check) and `deno task check:responses`: clean
- `deno task test:unit`: 1196 passed, 0 failed, 7 ignored
- Both PRs: CI green on their final heads (incl. Lighthouse + Newman) and gates rerun locally by the reviewer before merge.

## Runtime-behaviour notes for the deploy
- Watch `X-BTC-Balance-Status` distribution in the daily regression artifacts: once both providers fail, `unavailable` now returns near-instantly for the rest of the 20 s window, so an outage shows up in status, not latency.
- CDN copies of `/s/<cpid>` SVG/JS now live up to a year (browser `Cache-Control`; consistent with `/content/*.svg`). If the SVG rewrite logic in `handleTextContent` changes later, purge those paths.
- No env, secret, task-definition or DB schema changes.

## Before merging
- Rollback target: register a digest-pinned task-definition revision (current image is from #1247, task def `:146`).
- Expect the usual ~5 min mixed HTML/JS window while the old target drains.