### PR TITLE
fix(security): require the internal API key on the circuit-breaker reset route

### DIFF
--- a/routes/api/internal/test-reset-circuit-breakers.ts
+++ b/routes/api/internal/test-reset-circuit-breakers.ts
@@ -1,9 +1,16 @@
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { CircuitBreakerService } from "$server/services/infrastructure/circuitBreaker.ts";
+import { InternalRouteGuard } from "$server/services/security/internalRouteGuard.ts";
 
+// Operational endpoint: resetting every circuit breaker re-opens traffic to
+// upstreams that tripped for a reason, and the metrics expose upstream health.
+// Both methods require the internal API key, like the sibling monitoring and
+// debug-headers routes; this handler shipped without any guard.
 export const handler: Handlers = {
-  POST(_req) {
+  POST(req) {
+    const accessError = InternalRouteGuard.requireAPIKey(req);
+    if (accessError) return accessError;
     try {
       // Reset all circuit breakers
       CircuitBreakerService.resetAllBreakers();
@@ -20,7 +27,9 @@ export const handler: Handlers = {
     }
   },
 
-  GET(_req) {
+  GET(req) {
+    const accessError = InternalRouteGuard.requireAPIKey(req);
+    if (accessError) return accessError;
     try {
       // Get all circuit breaker metrics
       const metrics = CircuitBreakerService.getAllMetrics();

--- a/tests/unit/internalCircuitBreakerRouteGuard.test.ts
+++ b/tests/unit/internalCircuitBreakerRouteGuard.test.ts
@@ -1,0 +1,67 @@
+/**
+ * /api/internal/test-reset-circuit-breakers must require the internal API key
+ * for both methods. It shipped unguarded, so anyone could POST to re-open every
+ * circuit breaker in production and GET upstream health metrics.
+ */
+import { assertEquals } from "@std/assert";
+import { handler } from "../../routes/api/internal/test-reset-circuit-breakers.ts";
+
+type RouteHandler = (
+  req: Request,
+  ctx: unknown,
+) => Response | Promise<Response>;
+const post = handler.POST as RouteHandler;
+const get = handler.GET as RouteHandler;
+
+// serverConfig.INTERNAL_API_KEY is a getter over Deno.env, so the env var is
+// the only knob; always restore it so nothing leaks into other test files.
+function withApiKey(key: string, fn: () => Promise<void>) {
+  const original = Deno.env.get("INTERNAL_API_KEY");
+  Deno.env.set("INTERNAL_API_KEY", key);
+  return fn().finally(() => {
+    if (original === undefined) Deno.env.delete("INTERNAL_API_KEY");
+    else Deno.env.set("INTERNAL_API_KEY", original);
+  });
+}
+
+const url = "http://localhost/api/internal/test-reset-circuit-breakers";
+
+Deno.test("circuit-breaker reset: POST without X-API-Key is rejected", async () => {
+  await withApiKey("test-internal-key", async () => {
+    const res = await post(new Request(url, { method: "POST" }), {});
+    assertEquals(res.status, 401);
+    await res.body?.cancel();
+  });
+});
+
+Deno.test("circuit-breaker reset: POST with a wrong key is rejected", async () => {
+  await withApiKey("test-internal-key", async () => {
+    const res = await post(
+      new Request(url, { method: "POST", headers: { "X-API-Key": "nope" } }),
+      {},
+    );
+    assertEquals(res.status >= 400, true);
+    await res.body?.cancel();
+  });
+});
+
+Deno.test("circuit-breaker metrics: GET without X-API-Key is rejected", async () => {
+  await withApiKey("test-internal-key", async () => {
+    const res = await get(new Request(url), {});
+    assertEquals(res.status, 401);
+    await res.body?.cancel();
+  });
+});
+
+Deno.test("circuit-breaker reset: correct key still resets and reports", async () => {
+  await withApiKey("test-internal-key", async () => {
+    const headers = { "X-API-Key": "test-internal-key" };
+    const reset = await post(new Request(url, { method: "POST", headers }), {});
+    assertEquals(reset.status, 200);
+    const body = await reset.json();
+    assertEquals(body.message, "All circuit breakers reset successfully");
+    const metrics = await get(new Request(url, { headers }), {});
+    assertEquals(metrics.status, 200);
+    assertEquals(typeof (await metrics.json()).circuitBreakers, "object");
+  });
+});


### PR DESCRIPTION
## Why
`routes/api/internal/test-reset-circuit-breakers.ts` had no guard. Verified on production on 2026-09-08: `GET /api/internal/test-reset-circuit-breakers` returned 200 with breaker metrics to an anonymous client, and the `POST` (which calls `CircuitBreakerService.resetAllBreakers()`) was equally reachable. Re-opening every breaker on demand lets anyone force traffic back to an upstream that tripped for a reason.

## Change
Both methods now call `InternalRouteGuard.requireAPIKey(req)` first, matching `monitoring.ts` and `debug-headers.ts`. No behaviour change for keyed callers.

## Validation
- New `tests/unit/internalCircuitBreakerRouteGuard.test.ts`: 401 without key (POST and GET), rejection with a wrong key, keyed POST still resets and keyed GET still reports.
- `deno task check:responses`, `deno fmt --check`, `deno lint`, `deno check`: clean
- `deno task test:unit`: see reviewer note